### PR TITLE
Icon columns

### DIFF
--- a/aemedge/blocks/columns/columns.css
+++ b/aemedge/blocks/columns/columns.css
@@ -3,6 +3,15 @@
   flex-direction: column;
 }
 
+.columns > div > div {
+  order: 1;
+}
+
+.columns.icons > div {
+  display: flex;
+  flex-direction: row;
+}
+
 .columns img {
   width: 30%;
 }
@@ -11,8 +20,8 @@
   width: 100%;
 }
 
-.columns > div > div {
-  order: 1;
+.columns span.icon img {
+  width: 100%;
 }
 
 .columns > div > .columns-img-col {
@@ -21,6 +30,34 @@
 
 .columns > div > .columns-img-col img {
   display: block;
+}
+
+.columns span.icon {
+  display: inline-block;
+  height: 24px;
+  width: 24px;
+}
+
+.columns.icons {
+  place-content: normal center;
+  align-items: center;
+  fill-opacity: 0.6;
+}
+
+.columns.icons span {
+  display: flex;
+  align-items: center;
+  fill-opacity: 0.6;
+  margin: 20px;
+}
+
+.columns.icons span.icon {
+  display: unset;
+}
+
+.columns.icons span.icon img {
+  height: 20px;
+  width: 80px;
 }
 
 @media (width >= 992px) {
@@ -33,5 +70,10 @@
   .columns > div > div {
     flex: 1;
     order: unset;
+  }
+
+  .columns.icons span.icon img {
+    width: 96px;
+    height: 36px;
   }
 }

--- a/aemedge/blocks/global-banner/global-banner.css
+++ b/aemedge/blocks/global-banner/global-banner.css
@@ -8,7 +8,6 @@ main .section.global-banner-container {
   margin: 0;
   padding: 0;
   width: 100vw;
-  height: 100%;
   z-index: 10;
 }
 

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -201,7 +201,6 @@ function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
     buildFragmentBlocks(main);
-    // buildCtaBanners(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -105,9 +105,9 @@ export function buildMultipleButtons(main) {
 
 export function buildCtaBanners(main) {
   // cta banner
-  const columns = main.querySelectorAll('div.columns');
+  const columns = main.querySelectorAll('.section.cta-banner div.columns-wrapper');
   columns.forEach((column) => {
-    const pictures = column.parentElement.querySelectorAll(':scope > p picture');
+    const pictures = column.parentElement.querySelectorAll('p picture');
     if (pictures) {
       const images = [];
       pictures.forEach((picture, idx) => {
@@ -122,6 +122,7 @@ export function buildCtaBanners(main) {
       });
       const blogHero = buildBlock('blog-hero', { elems: images });
       column.parentElement.prepend(blogHero);
+      decorateBlock(blogHero);
     }
   });
 }
@@ -200,7 +201,7 @@ function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
     buildFragmentBlocks(main);
-    buildCtaBanners(main);
+    // buildCtaBanners(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);
@@ -219,6 +220,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  buildCtaBanners(main);
 }
 
 /**

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -24,6 +24,7 @@
   --primary-button-color:#ce4c00;
   --invalid-red: #e90000;
   --input-background-color: #eaeaec;
+  --dark-background-color: rgb(23 23 37);
 
   /* fonts */
   --body-font-family: proxima-nova, proxima-nova-fallback, sans-serif;
@@ -281,6 +282,22 @@ main .section {
   object-position: center center;
 }
 
+/* Section with Dark or Centered content */
+.section.dark {
+  background-color: var(--dark-background-color);
+  color: var(--light-color);
+}
+
+.section.center {
+  text-align: center;
+}
+
+/* specially for supported devices illustration */
+.section.dark.center.columns-container span.icon:first-of-type {
+  height: 103px;
+  width: 108px;
+}
+
 @media (width >= 768px) {
   main .section {
     padding: 64px 32px;
@@ -291,6 +308,14 @@ main .section {
     flex-direction: row;
     justify-content: space-between;
     padding: 3.75rem;
+  }
+
+  /* Section with Dark or Centered content */
+  .section.center > * {
+    max-width: 1200px;
+    align-items: center;
+    width: 100%;
+    margin: 0 auto;
   }
 
 }


### PR DESCRIPTION
Added styles for .section.dark and .section.center
Handling Columns block with (icons) variant
Fixed issues with cta-banner and global-banner that were found after I authored the homepage

Fix #86 

Test URLs:
- Before: https://main--sling--aemsites.aem.page/
- After: https://icon-columns--sling--aemsites.aem.page/
