### PR TITLE
75 - Global buttons relocate + style

### DIFF
--- a/aemedge/blocks/header/header.css
+++ b/aemedge/blocks/header/header.css
@@ -310,7 +310,7 @@ header nav[aria-expanded='true'] .nav-tools {
   left: calc(87% / 2);
 }
 
-header nav .nav-tools a.button:any-link {
+header nav .nav-tools a:any-link {
   all: unset;
   font-size: 1rem;
   font-weight: 600;
@@ -321,7 +321,7 @@ header nav .nav-tools a.button:any-link {
   text-decoration: none;
 }
 
-header nav .nav-tools a.button:hover {
+header nav .nav-tools a:hover {
   cursor: pointer;
 }
 
@@ -336,7 +336,7 @@ header nav .nav-tools a.button:hover {
     white-space: nowrap;
   }
 
-  header nav .nav-tools a.button img {
+  header nav .nav-tools a img {
     height: 16px;
     width: 16px;
     padding-right: 0.313rem;

--- a/aemedge/blocks/tabs/tabs.js
+++ b/aemedge/blocks/tabs/tabs.js
@@ -1,7 +1,9 @@
 // eslint-disable-next-line import/no-unresolved
 import {
-  toClassName, buildBlock, decorateBlock, loadBlocks, decorateButtons,
+  toClassName, buildBlock, decorateBlock, loadBlocks,
 } from '../../scripts/aem.js';
+
+import { decorateButtons } from '../../scripts/scripts.js';
 
 const AVAILABLE_SUB_BLOCKS = ['accordion', 'columns'];
 

--- a/aemedge/scripts/aem.js
+++ b/aemedge/scripts/aem.js
@@ -414,43 +414,7 @@ function wrapTextNodes(block) {
   });
 }
 
-/**
- * Decorates paragraphs containing a single link as buttons.
- * @param {Element} element container element
- */
-function decorateButtons(element) {
-  element.querySelectorAll('a').forEach((a) => {
-    a.title = a.title || a.textContent;
-    if (a.href !== a.textContent) {
-      const up = a.parentElement;
-      const twoup = a.parentElement.parentElement;
-      if (!a.querySelector('img')) {
-        if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
-          a.className = 'button'; // default
-          up.classList.add('button-container');
-        }
-        if (
-          up.childNodes.length === 1
-          && up.tagName === 'STRONG'
-          && twoup.childNodes.length === 1
-          && twoup.tagName === 'P'
-        ) {
-          a.className = 'button primary';
-          twoup.classList.add('button-container');
-        }
-        if (
-          up.childNodes.length === 1
-          && up.tagName === 'EM'
-          && twoup.childNodes.length === 1
-          && twoup.tagName === 'P'
-        ) {
-          a.className = 'button secondary';
-          twoup.classList.add('button-container');
-        }
-      }
-    }
-  });
-}
+// moving decorateButtons to scripts.js
 
 /**
  * Add <img> for icon, prefixed with codeBasePath and optional prefix.
@@ -747,7 +711,6 @@ export {
   createOptimizedPicture,
   decorateBlock,
   decorateBlocks,
-  decorateButtons,
   decorateIcons,
   decorateSections,
   decorateTemplateAndTheme,

--- a/aemedge/scripts/aem.js
+++ b/aemedge/scripts/aem.js
@@ -414,7 +414,43 @@ function wrapTextNodes(block) {
   });
 }
 
-// moving decorateButtons to scripts.js
+/**
+ * Decorates paragraphs containing a single link as buttons.
+ * @param {Element} element container element
+ */
+function decorateButtons(element) {
+  element.querySelectorAll('a').forEach((a) => {
+    a.title = a.title || a.textContent;
+    if (a.href !== a.textContent) {
+      const up = a.parentElement;
+      const twoup = a.parentElement.parentElement;
+      if (!a.querySelector('img')) {
+        if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
+          a.className = 'button'; // default
+          up.classList.add('button-container');
+        }
+        if (
+          up.childNodes.length === 1
+          && up.tagName === 'STRONG'
+          && twoup.childNodes.length === 1
+          && twoup.tagName === 'P'
+        ) {
+          a.className = 'button primary';
+          twoup.classList.add('button-container');
+        }
+        if (
+          up.childNodes.length === 1
+          && up.tagName === 'EM'
+          && twoup.childNodes.length === 1
+          && twoup.tagName === 'P'
+        ) {
+          a.className = 'button secondary';
+          twoup.classList.add('button-container');
+        }
+      }
+    }
+  });
+}
 
 /**
  * Add <img> for icon, prefixed with codeBasePath and optional prefix.
@@ -711,6 +747,7 @@ export {
   createOptimizedPicture,
   decorateBlock,
   decorateBlocks,
+  decorateButtons,
   decorateIcons,
   decorateSections,
   decorateTemplateAndTheme,

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -153,8 +153,10 @@ export function decorateButtons(element) {
   element.querySelectorAll('a').forEach((a) => {
     a.title = a.title || a.textContent;
     if (a.href !== a.textContent) {
+      const hasIcon = a.querySelector('.icon');
       const up = a.parentElement;
       const twoup = a.parentElement.parentElement;
+      if (hasIcon) return;
       if (!a.querySelector('img')) {
         // let default button be text-only, no decoration
         const linkText = a.textContent;

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -2,7 +2,6 @@ import {
   sampleRUM,
   buildBlock,
   loadFooter,
-  decorateButtons,
   decorateIcons,
   decorateSections,
   decorateBlocks,
@@ -143,6 +142,53 @@ async function buildGlobalBanner(main) {
       await loadBlock(fragment);
     }
   }
+}
+
+/**
+ * Decorates paragraphs containing a single link as buttons.
+ * @param {Element} element container element
+ */
+export function decorateButtons(element) {
+  element.querySelectorAll('a').forEach((a) => {
+    a.title = a.title || a.textContent;
+    if (a.href !== a.textContent) {
+      const up = a.parentElement;
+      const twoup = a.parentElement.parentElement;
+      if (!a.querySelector('img')) {
+        // let default button be text-only, no decoration
+        const linkText = a.textContent;
+        const linkTextEl = document.createElement('span');
+        linkTextEl.classList.add('link-button-text');
+        linkTextEl.append(linkText);
+        a.textContent = `${linkText}`;
+        a.setAttribute('aria-label', `${linkText}`);
+        if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
+          a.textContent = '';
+          a.className = 'button text'; // default
+          up.classList.add('button-container');
+          a.append(linkTextEl);
+        }
+        if (
+          up.childNodes.length === 1
+          && up.tagName === 'STRONG'
+          && twoup.childNodes.length === 1
+          && twoup.tagName === 'P'
+        ) {
+          a.className = 'button primary';
+          twoup.classList.add('button-container');
+        }
+        if (
+          up.childNodes.length === 1
+          && up.tagName === 'EM'
+          && twoup.childNodes.length === 1
+          && twoup.tagName === 'P'
+        ) {
+          a.className = 'button secondary';
+          twoup.classList.add('button-container');
+        }
+      }
+    }
+  });
 }
 
 /**

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -133,6 +133,15 @@ em strong {
   font-size: 1em;
 }
 
+.blog-article strong em,
+.blog-category strong em,
+.blog-article em strong,
+.blog-category em strong {
+    font-style: normal;
+    color: var(--text-color);
+    font-size: unset;
+}
+
 /* links */
 a:any-link {
   color: var(--link-color);
@@ -171,7 +180,26 @@ a.button:hover, a.button::-moz-focus-inner  {
   cursor: pointer;
 }
 
-a.button:hover {
+a.button.primary, button.primary,
+a.button.secondary, button.secondary{
+  color: var(--background-color);
+  background-color: var(--primary-button-color);
+  border: 2px solid var(--primary-button-color);
+  border-radius: 0.125rem;
+  opacity: 1;
+  min-width: 11.25rem;
+  font-size: 1rem;
+  padding: 0.875rem 1rem;
+}
+
+a.button.secondary, button.secondary {
+  color: var(--text-color);
+  background-color: var(--light-color);
+  border: 2px solid var(--light-color);
+}
+
+a.button.primary:hover,
+a.button.secondary:hover {
   outline: none;
   box-shadow: #07070b66 0 24px 57px 0;
   opacity: 1;
@@ -184,12 +212,6 @@ button:disabled, button:disabled:hover {
   cursor: unset;
 }
 
-a.button.secondary, button.secondary {
-  background-color: unset;
-  border: 2px solid currentcolor;
-  color: var(--text-color)
-}
-
 /* Buttons Container */
 .buttons-container {
   display: flex;
@@ -199,6 +221,52 @@ a.button.secondary, button.secondary {
 
 .buttons-container a.button {
   margin: 8px;
+}
+
+a.button.text, button.text {
+  background-color: unset;
+  border: 0;
+  text-align: unset;
+  font-size: inherit;
+  margin: unset;
+  padding: unset;
+  white-space: normal;
+  font-weight: bold;
+  font-style: inherit;
+  border-radius: unset;
+  line-height: inherit;
+  text-transform: none;
+  color: var(--link-color);
+}
+
+a.button.text:hover, button.text:hover {
+  background-color: unset;
+  color: var(--link-hover-color);
+  box-shadow: none;
+}
+
+.offer-details .buttons-container  {
+  display: block;
+}
+
+.offer-details .button.text {
+  font-weight: normal;
+  font-style: italic;
+  font-size: 14px;
+  margin-left: 10px;
+}
+
+.offer-details a.button.text {
+  color: white;
+}
+
+.offer-details a.button.text:hover {
+  text-decoration: underline;
+}
+
+.offer-details .button-container p {
+  line-height: 1em;
+  margin: 0;
 }
 
 main img {


### PR DESCRIPTION
1. Added "text" as the default style
2. Styled secondary button style
3. moved decorateButtons to scripts.js
4. added styles specific to the "try-sling" fragment called "offer-details" where the 2nd button is unstyled, small font
5. Created strong + em text style for blog-article and blog-category template pages that isn't yellow

Fix #75

Test URLs:
See these buttons to test items 2 + 4
- Before: https://main--sling--aemsites.aem.page/indexcharity
- After: https://75-buttons--sling--aemsites.aem.page/indexcharity

See bottom of this page (just before the last video) to test items 1 + 5

- Before: https://main--sling--aemsites.aem.page/whatson/entertainment/holiday/christmas-movies-shows
- After: https://75-buttons--sling--aemsites.aem.page/whatson/entertainment/holiday/christmas-movies-shows
