### PR TITLE
New default index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,0 +1,51 @@
+version: 1
+indices:
+  default:
+    include:
+      - '/whatson/**'
+    exclude:
+      - '/drafts/**'
+      - '/tools/sidekick/**'
+      - '/fragments/**'
+    target: /query-index.json
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          attribute(el, 'content')
+      desktopImage:
+        select: main > div:nth-of-type(1) picture:nth-of-type(1) img
+        value: |
+          match(attribute(el, "src"), "^.{2}(.*)$")
+      mobileImage:
+        select: main > div:nth-of-type(1) picture:nth-of-type(2) img
+        value: |
+          match(attribute(el, "src"), "^.{2}(.*)$")
+      tags:
+        select: head > meta[property="article:tag"]
+        value: |
+          attribute(el, 'content')
+      date:
+        select: head > meta[name="publication-date"]
+        value: |
+          parseTimestamp(attribute(el, 'content'), 'MM/DD/YYYY')
+      template:
+        select: head > meta[name="template"]
+        value: |
+          attribute(el, 'content')
+      author:
+        select: head > meta[name="author"]
+        value: |
+          attribute(el, 'content')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -24,7 +24,7 @@ indices:
       desktopImage:
         select: main > div:nth-of-type(1) picture:nth-of-type(1) img
         value: |
-          match(attribute(el, "src"), "^.{2}(.*)$")
+          match(attribute(el, "src"), "^.{2}([^?]*)")
       mobileImage:
         select: main > div:nth-of-type(1) picture:nth-of-type(2) img
         value: |


### PR DESCRIPTION
Custom index to get the desktop + mobile image file names. Then they can be used for the Large Cards on category pages.


Fix #67 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/
- After: https://67-indeximages--sling--aemsites.aem.live/
