### PR TITLE
fix index target path

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -7,7 +7,7 @@ indices:
       - '/drafts/**'
       - '/tools/sidekick/**'
       - '/fragments/**'
-    target: /query-index.json
+    target: /whatson/query-index.json
     properties:
       title:
         select: head > meta[property="og:title"]


### PR DESCRIPTION
quick fix for path of custom index

Fix #

Test URLs:
- Before: https://main--sling--aemsites.aem.live/
- After: https://64-largecard--sling--aemsites.aem.live/
