### PR TITLE
big cleanup of article template layout CSS

### DIFF
--- a/aemedge/blocks/blog-breadcrumb/blog-breadcrumb.css
+++ b/aemedge/blocks/blog-breadcrumb/blog-breadcrumb.css
@@ -7,7 +7,7 @@
     color: #454550;
     font-size: 18px;
     margin: 0 auto;
-    padding: 12px 10%;
+    padding: 8px 10% 14px;
     text-align: center;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -26,7 +26,7 @@ a.blog-breadcrumb-link {
 .blog-breadcrumb span.icon-fw-arrow {
     width: unset;
     height: unset;
-    margin: 0 10px;
+    margin: 0 14px;
     display: inline-block;
     font: normal normal normal 20px / 1 var(--font-awesome);
     text-rendering: auto;

--- a/aemedge/blocks/popular-blogs/popular-blogs.css
+++ b/aemedge/blocks/popular-blogs/popular-blogs.css
@@ -182,7 +182,6 @@
 }
 
 @media (width >=1200px) {
-
     .popular-blogs .slides-container {
         overflow: unset;
         width: 100%;

--- a/aemedge/blocks/popular-blogs/popular-blogs.css
+++ b/aemedge/blocks/popular-blogs/popular-blogs.css
@@ -12,7 +12,6 @@
 
 .popular-blogs .slides-wrapper {
     position: relative;
-    overflow-x: auto;
     width: 100%;
 }
 
@@ -183,9 +182,6 @@
 }
 
 @media (width >=1200px) {
-    .section.popular-blogs-container {
-        max-width: 1440px;
-    }
 
     .popular-blogs .slides-container {
         overflow: unset;

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -157,20 +157,11 @@ main pre {
 }
 
 /* Fire style */
-strong em,
-em strong {
+.columns strong em,
+.columns em strong {
   font-style: normal;
   color: #faa21b;
   font-size: 1em;
-}
-
-.blog-article strong em,
-.blog-category strong em,
-.blog-article em strong,
-.blog-category em strong {
-  font-style: normal;
-  color: var(--text-color);
-  font-size: unset;
 }
 
 /* links */
@@ -217,14 +208,18 @@ a.button.primary,
 button.primary,
 a.button.secondary,
 button.secondary {
-  color: var(--background-color);
-  background-color: var(--primary-button-color);
-  border: 2px solid var(--primary-button-color);
   border-radius: 0.125rem;
   opacity: 1;
   min-width: 11.25rem;
   font-size: 1rem;
   padding: 0.875rem 1rem;
+}
+
+a.button.primary,
+button.primary {
+  color: var(--background-color);
+  background-color: var(--primary-button-color);
+  border: 2px solid var(--primary-button-color);
 }
 
 a.button.secondary,
@@ -417,7 +412,7 @@ main .section {
   }
 
   /* Section with Dark or Centered content */
-  .section.center>* {
+  .section.center >* {
     max-width: 1200px;
     align-items: center;
     width: 100%;

--- a/aemedge/templates/blog-article/blog-article.css
+++ b/aemedge/templates/blog-article/blog-article.css
@@ -1,11 +1,37 @@
+.blog-article h2,
+.blog-article h3,
+.blog-article h4 {
+    margin: 36px auto 10px;
+    line-height: 1.1;
+}
 
 .blog-article h1 {
+    margin: 10px auto 24px;
+    line-height: 1.1;
     text-align: center;
+}
+
+.blog-article h4 {
     margin: 10px auto;
+}
+
+.blog-article h2 strong,
+.blog-article strong h2,
+.blog-article h3 strong,
+.blog-article strong h3,
+.blog-article h4 strong,
+.blog-article strong h4 {
+    text-align: center;
+    display: inline-block;
+    width: 100%;
 }
 
 .blog-article p {
     line-height: 1.5em;
+}
+
+.blog-article .video {
+    margin: 16px auto;
 }
 
 main .hero-container + .section {
@@ -21,27 +47,15 @@ main .hero-container + .section {
     margin: 0 auto;
 }
 
-main .hero-container + .section h1, h2, h3, h4 {
-    text-align: center;
-    margin-bottom: 10px;
-}
-
-main .hero-container + .section p {
-    line-height: 24px;
-}
-
-main .hero-container .blog-primary-title {
-    line-height: 35px;
-    color: #1d1d1d;
-    max-width: 770px;
-    text-align: center;
+.blog-article > main .section.popular-blogs-container {
+    padding: 37px 0;
+    width: 100%
 }
 
 .author-details-wrapper {
-    margin: 0 auto 32px;
     min-height: 160px;
     min-width: 300px;
-    background-color: #fff;
+    background-color: var(--clr-white);
     border-radius: 4px;
     display: flex;
     flex-direction: column;
@@ -56,15 +70,13 @@ main .hero-container .blog-primary-title {
     list-style: none;
  }
 
-.author-card .image-container
-{
+.author-card .image-container {
     align-self: stretch;
     margin: 0 auto;
     width: 60px;
 }
 
-.author-card .image-container img
-{
+.author-card .image-container img {
     margin-top: 8px;
     padding: 0;
     text-align: center;
@@ -75,6 +87,8 @@ main .hero-container .blog-primary-title {
 
 .text-container {
     text-align: center;
+    font-size: var(--body-font-size-xs);
+    line-height: 1em;
 }
 
 .text-container .auth-name {
@@ -85,7 +99,6 @@ main .hero-container .blog-primary-title {
 
 .text-container .tags,
 .text-container .pub-date {
-    line-height: 1em;
     padding-top: 16px;
 }
 
@@ -93,6 +106,7 @@ main .hero-container .blog-primary-title {
     color: var(--text-color);
     font-size: 14px;
     font-weight: 500;
+    line-height: 1.1;
     text-decoration: none;
     text-transform: uppercase;
 }
@@ -100,12 +114,14 @@ main .hero-container .blog-primary-title {
 .text-container .social-share {
     display: flex;
    text-align: center;
-   padding:20px 0 10px;
+   padding:24px 0 6px;
    justify-content: center;
 }
 
 .text-container .social-share .share-text {
     word-break: keep-all;
+    margin-top: 4px;
+    margin-bottom: 16px;
 }
 
 .social-share .social-share-icon {
@@ -201,7 +217,6 @@ main .hero-container .blog-primary-title {
     cursor: pointer;
 }
 
-
 body.blog-article.modal-open {
     position: fixed;
     inset: 0;
@@ -213,8 +228,7 @@ body.blog-article.modal-open {
 
 
 body.blog-article.modal-open .modal-content {
-max-height: unset;
-
+    max-height: unset;
 }
 
 body.blog-article.modal-open .modal-content .section:first-of-type > div {
@@ -225,48 +239,78 @@ body.blog-article.modal-open .modal-content .section:first-of-type > div {
 }
 
 @media (width >= 768px) {
-.author-card {
-    margin: 20px 10px;
+    .blog-article h1 {
+        margin: 10px auto 32px;
+        line-height: 55px;
+        text-align: center;
+        max-width: 770px;
+    }
+
+    .author-card {
+        margin: 20px 10px;
+    }
+
+    .content-details-wrapper {
+        width: 66%;
+        margin: 0 auto 0 2%;
+    }
+
+    .content-details-wrapper >.default-content-wrapper > *:first-child {
+        margin-top: 0;
+    }
+
+    .blog-article main > .section {
+        width: 100%;
+        padding: 0;
+    }
+
+    .blog-article > main .section:not(.blog-hero-container) {
+        padding: unset;
+        width: unset;
+    }
+
+    .blog-article > main .section.popular-blogs-container {
+        padding: 37px 0;
+        width: 100%;
+        max-width: 1440px;
+    }
+
+    body.blog-article .modal dialog {
+        padding: 0 20px 20px;
+        max-width: 896px;
+        width: 100%;
+        border-radius: 0.5rem;
+        margin-top: 100px;
+        position: relative;
+        z-index: 99;
+        box-sizing: border-box;
+    }
+
+    .blog-details-wrapper {
+        flex-direction: row;
+    }
+
+    .author-details-wrapper {
+        align-self: flex-start;
+        min-width: 110px;
+        max-width: 168px;
+        width: 15%;
+        margin-left: 8px;
+        word-break: break-word;
+    }
+
+    .text-container .social-share {
+        flex-direction: column;
+    }
 }
 
-body.blog-article .modal dialog {
-    padding: 0 20px 20px;
-    max-width: 896px;
-    width: 100%;
-    border-radius: 0.5rem;
-    margin-top: 100px;
-    position: relative;
-    z-index: 99;
-    box-sizing: border-box;
+@media (width >= 1024px) {
+.blog-article > main .section:not(.popular-blogs-container) {
+    max-width: 1168px;
 }
 
-.blog-details-wrapper {
-    flex-direction: row;
-}
-
-.author-details-wrapper {
-    align-self: flex-start;
-    min-width: 110px;
-    max-width: 168px;
-    min-height: unset;
-    margin:24px 24px 24px 0;
-    width: 100%;
-}
-
-.blog-article main > .section:not(.blog-hero-container) {
-    width: 90%;
-}
-
-.text-container .social-share {
-    flex-direction: column;
-}
-}
-
-@media (width >= 992px) {
 .section.blog-hero-container {
-   margin-top:64px;
-   padding: 0;
-   width: 100%;
+    margin: 64px auto 0;
 }
 
 .text-container .tags {
@@ -301,21 +345,9 @@ main .hero-container + .section p {
     line-height: unset;
 }
 
-.blog-article .content-details-wrapper {
-    width: 66%;
-    margin: unset;
-}
-
 .content-details-wrapper .fragment-wrapper .button-container + p{
     display: flex;
     justify-content: center;
 }
 }
 
-@media (width >= 1200px) {
-.blog-article .section > div {
-    max-width: 1168px;
-    margin: auto;
-    padding: 0;
-}
-}


### PR DESCRIPTION
Compare against the real site pages is mobile and desktop.

Also in this PR I have added the logic for using bold + h2 - h4 as "text-align: center", which the 3rd test link was re-imported with Kiran's addition of that logic to the importer.
Fixes #113, #121

Test URLs:
- Before: https://main--sling--aemsites.aem.page/whatson/entertainment/holiday/lifetime-christmas-movie-guide
- After: https://113-articletemplate--sling--aemsites.aem.page/whatson/entertainment/holiday/lifetime-christmas-movie-guide

- Before: https://main--sling--aemsites.aem.page/whatson/entertainment/exclusives/black-history-month-sling-tv
- After: https://113-articletemplate--sling--aemsites.aem.page/whatson/entertainment/exclusives/black-history-month-sling-tv

- Before: https://main--sling--aemsites.aem.page/whatson/sports/nhl/nhl-stanley-cup-playoffs-schedule-sling
- After: https://113-articletemplate--sling--aemsites.aem.page/whatson/sports/nhl/nhl-stanley-cup-playoffs-schedule-sling

- Before: https://main--sling--aemsites.aem.page/whatson/international/arabic/mant-rayeg-ar
- After: https://113-articletemplate--sling--aemsites.aem.page/whatson/international/arabic/mant-rayeg-ar
