### PR TITLE
overall fixing of spacing of divs

### DIFF
--- a/aemedge/blocks/footer/footer.css
+++ b/aemedge/blocks/footer/footer.css
@@ -243,7 +243,6 @@ vertical-align: middle;
 }
 
 @media (width >= 1200px) {
-
   .footer .footer-primary-links {
     margin-left: 0;
   }

--- a/aemedge/blocks/footer/footer.css
+++ b/aemedge/blocks/footer/footer.css
@@ -169,7 +169,7 @@ vertical-align: middle;
     justify-content: space-between;
     width: calc(100% - 48px);
     max-width: 950px;
-    margin-left: 24px;
+    margin-left: 16px;
   }
 
   footer li.nav-item.nav-heading {
@@ -197,8 +197,8 @@ vertical-align: middle;
   .footer .section.footer-primary {
     margin: 0 auto;
     width: 100%;
-    max-width: 1436px;
     flex-flow: row;
+    max-width: 1200px;
   }
 
 .footer .section.footer-secondary {
@@ -240,4 +240,21 @@ vertical-align: middle;
   .footer-secondary .sec-footer-links {
     justify-content: flex-end;
   }
+}
+
+@media (width >= 1200px) {
+
+  .footer .footer-primary-links {
+    margin-left: 0;
+  }
+
+  .footer-primary .nav-items-wrapper.footer-social-links {
+    margin-right: 0;
+  }
+}
+
+@media (width >= 1440px) {
+  .footer .section.footer-primary {
+    max-width: 1472px;
+    }
 }

--- a/aemedge/blocks/whatson-header/whatson-header.css
+++ b/aemedge/blocks/whatson-header/whatson-header.css
@@ -18,7 +18,7 @@ header nav {
     margin: auto;
     max-width: 1400px;
     height: var(--nav-height);
-    padding: 0 1rem;
+    padding: 0 24px;
     font-family: var(--body-font-family);
 }
 
@@ -30,17 +30,12 @@ header nav[aria-expanded="true"] {
     min-height: 100vh;
 }
 
-@media (width >=768px) {
-    header nav {
-        padding: 0 2rem;
-    }
-}
-
 @media (width >=1400px) {
     header nav {
         display: flex;
         justify-content: space-between;
         position: relative;
+        max-width: 85%;
     }
 
     header nav[aria-expanded="true"] {
@@ -104,8 +99,8 @@ header .nav-brand {
 }
 
 header nav .nav-brand img {
-    width: 128px;
-    height: auto;
+    width: auto;
+    height: 40px;
 }
 
 /* sections */
@@ -333,7 +328,7 @@ header nav .nav-search {
         flex-direction: column;
         align-items: center;
         justify-content: baseline;
-        width: 100%; 
+        width: 100%;
         overflow: hidden auto;
         height: 60vh;
     }

--- a/aemedge/templates/blog-article/blog-article.css
+++ b/aemedge/templates/blog-article/blog-article.css
@@ -250,12 +250,22 @@ body.blog-article.modal-open .modal-content .section:first-of-type > div {
         margin: 20px 10px;
     }
 
-    .content-details-wrapper {
+    .blog-article main .default-content-wrapper {
+        width: 66%;
+        margin: 0 auto 0 17%;
+    }
+
+    .blog-article main .content-details-wrapper {
         width: 66%;
         margin: 0 auto 0 2%;
     }
 
-    .content-details-wrapper >.default-content-wrapper > *:first-child {
+    .blog-article main .content-details-wrapper .default-content-wrapper {
+        width: unset;
+        margin: 0;
+    }
+
+    .blog-article main .content-details-wrapper >.default-content-wrapper > *:first-child {
         margin-top: 0;
     }
 
@@ -267,6 +277,8 @@ body.blog-article.modal-open .modal-content .section:first-of-type > div {
     .blog-article > main .section:not(.blog-hero-container) {
         padding: unset;
         width: unset;
+        margin-left: auto;
+        margin-right: auto;
     }
 
     .blog-article > main .section.popular-blogs-container {


### PR DESCRIPTION
This fixes the layout of divs not in the "blog details wrapper".
Also fixed are the image size and padding of the nav, and I added a new breakpoint to the footer.

Fix #135

Test URLs:
Compare with original page at https://www.sling.com/whatson/sports/nhl/nhl-stanley-cup-playoffs-schedule-sling, except for the table, which is being handled in a different ticket.

- Before: https://main--sling--aemsites.aem.page/whatson/sports/nhl/000-nhl-stanley-cup-playoffs-schedule-sling
- After: https://135-blogspacing--sling--aemsites.aem.page/whatson/sports/nhl/000-nhl-stanley-cup-playoffs-schedule-sling
