### PR TITLE
129 award icon logic for styling

### DIFF
--- a/aemedge/templates/blog-article/blog-article.css
+++ b/aemedge/templates/blog-article/blog-article.css
@@ -30,6 +30,16 @@
     line-height: 1.5em;
 }
 
+.blog-article .icon.award {
+    width: 20%;
+    height: auto;
+}
+
+.blog-article strong > .icon { /* centers the icon */
+    display: block;
+    margin: 0 auto;
+}
+
 .blog-article .video {
     margin: 16px auto;
 }
@@ -64,6 +74,7 @@ main .hero-container + .section {
     text-align: center;
     word-break: break-word;
     box-shadow: 0 5px 15px 0 #00000024;
+    margin-bottom: 32px;
 }
 
 .author-details-wrapper li {

--- a/aemedge/templates/blog-article/blog-article.js
+++ b/aemedge/templates/blog-article/blog-article.js
@@ -10,6 +10,13 @@ import {
 
 import { getTag } from '../../scripts/tags.js';
 
+// This depends on authors naming award icons starting with "award-"
+export function decorateAwardIcons() {
+  document.querySelectorAll('[class^="icon icon-award-"]').forEach((span) => {
+    span.classList.add('award');
+  });
+}
+
 /**
  * Function to return the name of the author photo
  * photos must be stored with <firstname>-<lastname>-author.jpeg
@@ -151,4 +158,5 @@ export default async function buildBlogDetails(main) {
   if (p) p.remove();
   buildFragmentBlocks(main);
   buildVideoBlocks(main);
+  decorateAwardIcons(main);
 }


### PR DESCRIPTION
Please see my copious notes in the issue description.
All the additional pages with this same image will need to have an import rule added, or re-authored.

Fix #129 

Test URLs:
My test page as authored, after converting the award image to an SVG and using icon notation:
- Before: https://129-imagesize--sling--aemsites.aem.page/whatson/sports/nhl/000-stream-nhl-hockey-games-live-sling-tv
- After: https://main--sling--aemsites.aem.page/whatson/sports/nhl/000-stream-nhl-hockey-games-live-sling-tv

Compare against original page with original image:
https://main--sling--aemsites.aem.page/whatson/sports/nhl/stream-nhl-hockey-games-live-sling-tv
Compare with live site:
https://www.sling.com/whatson/sports/nhl/stream-nhl-hockey-games-live-sling-tv