### PR TITLE
123 embed block added for FB, Twitter, Insta

### DIFF
--- a/aemedge/blocks/embed/embed.css
+++ b/aemedge/blocks/embed/embed.css
@@ -1,0 +1,62 @@
+.embed {
+    width: unset;
+    text-align: center;
+    max-width: 800px;
+    margin: 32px auto;
+}
+
+.embed > div {
+    display: flex;
+    justify-content: center;
+}
+
+.embed.embed-twitter .twitter-tweet-rendered {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.embed .embed-placeholder {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    position: relative;
+}
+
+.embed .embed-placeholder > * {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    inset: 0;
+}
+
+.embed .embed-placeholder picture img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.embed .embed-placeholder-play button {
+    box-sizing: border-box;
+    position: relative;
+    display: block;
+    transform: scale(3);
+    width: 22px;
+    height: 22px;
+    border: 2px solid;
+    border-radius: 20px;
+    padding: 0;
+}
+
+.embed .embed-placeholder-play button::before {
+    content: "";
+    display: block;
+    box-sizing: border-box;
+    position: absolute;
+    width: 0;
+    height: 10px;
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 6px solid;
+    top: 4px;
+    left: 7px;
+}

--- a/aemedge/blocks/embed/embed.css
+++ b/aemedge/blocks/embed/embed.css
@@ -33,7 +33,7 @@
     max-width: 560px;
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
     .embed {
         max-width: 560px;
     }

--- a/aemedge/blocks/embed/embed.css
+++ b/aemedge/blocks/embed/embed.css
@@ -1,7 +1,7 @@
 .embed {
-    width: unset;
+    width: 100%;
     text-align: center;
-    max-width: 560px;
+    max-width: 400px;
     margin: 32px auto;
 }
 
@@ -31,4 +31,10 @@
 
 .embed.embed-facebook {
     max-width: 560px;
+}
+
+@media (min-width: 768px) {
+    .embed {
+        max-width: 560px;
+    }
 }

--- a/aemedge/blocks/embed/embed.css
+++ b/aemedge/blocks/embed/embed.css
@@ -1,7 +1,7 @@
 .embed {
     width: unset;
     text-align: center;
-    max-width: 800px;
+    max-width: 560px;
     margin: 32px auto;
 }
 
@@ -13,6 +13,9 @@
 .embed.embed-twitter .twitter-tweet-rendered {
     margin-left: auto;
     margin-right: auto;
+
+    /* reserve an approximate space to avoid extensive layout shifts */
+    aspect-ratio: 4/3;
 }
 
 .embed .embed-placeholder {
@@ -21,42 +24,11 @@
     position: relative;
 }
 
-.embed .embed-placeholder > * {
+.embed.embed-instagram {
     display: flex;
-    align-items: center;
     justify-content: center;
-    position: absolute;
-    inset: 0;
 }
 
-.embed .embed-placeholder picture img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-}
-
-.embed .embed-placeholder-play button {
-    box-sizing: border-box;
-    position: relative;
-    display: block;
-    transform: scale(3);
-    width: 22px;
-    height: 22px;
-    border: 2px solid;
-    border-radius: 20px;
-    padding: 0;
-}
-
-.embed .embed-placeholder-play button::before {
-    content: "";
-    display: block;
-    box-sizing: border-box;
-    position: absolute;
-    width: 0;
-    height: 10px;
-    border-top: 5px solid transparent;
-    border-bottom: 5px solid transparent;
-    border-left: 6px solid;
-    top: 4px;
-    left: 7px;
+.embed.embed-facebook {
+    max-width: 560px;
 }

--- a/aemedge/blocks/embed/embed.js
+++ b/aemedge/blocks/embed/embed.js
@@ -33,7 +33,56 @@ const embedFacebook = (url) => {
   return embedHTML;
 };
 
-const loadEmbed = (block, link, autoplay) => {
+const embedInstagram = (url) => {
+  const endingSlash = url.pathname.endsWith('/') ? '' : '/';
+  const location = window.location.href.endsWith('.html') ? window.location.href : `${window.location.href}.html`;
+  // eslint-disable-next-line no-unused-vars
+  const src = `${url.origin}${url.pathname}${endingSlash}embed/?cr=1&amp;v=13&amp;wp=1316&amp;rd=${location}`;
+  const embedHTML = `<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="${url}" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);">
+  <div style="padding:16px;"><a href="${url}" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank">
+    <div style=" display: flex; flex-direction: row; align-items: center;">
+      <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div>
+      <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;">
+        <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div>
+        <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div>
+      </div>
+    </div>
+    <div style="padding: 19% 0;"></div>
+    <div style="display:block; height:50px; margin:0 auto 12px; width:50px;">
+      <span class="icon icon-instagram"></span>
+    </div>
+    <div style="padding-top: 8px;">
+      <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;">View this post on Instagram</div>
+    </div>
+    <div style="padding: 12.5% 0;"></div>
+    <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;">
+      <div>
+        <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div>
+        <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div>
+        <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div>
+      </div>
+      <div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div>
+      <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div>
+    </div>
+    <div style="margin-left: auto;">
+      <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div>
+      <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div>
+      <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div>
+    </div>
+  </div>
+  <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;">
+    <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;"></div>
+    <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"></div>
+  </div></a>
+  <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">
+    <a href="${url}" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A post shared by Eder</a>
+  </p>
+  </div></blockquote>`;
+  loadScript('https://www.instagram.com/embed.js');
+  return embedHTML;
+};
+
+const loadEmbed = (block, link) => {
   if (block.classList.contains('embed-is-loaded')) {
     return;
   }
@@ -47,12 +96,16 @@ const loadEmbed = (block, link, autoplay) => {
       match: ['twitter'],
       embed: embedTwitter,
     },
+    {
+      match: ['instagram'],
+      embed: embedInstagram,
+    },
   ];
 
   const config = EMBEDS_CONFIG.find((e) => e.match.some((match) => link.includes(match)));
   const url = new URL(link);
   if (config) {
-    block.innerHTML = config.embed(url, autoplay);
+    block.innerHTML = config.embed(url);
     block.classList = `block embed embed-${config.match[0]}`;
   } else {
     block.innerHTML = getDefaultEmbed(url);
@@ -62,26 +115,12 @@ const loadEmbed = (block, link, autoplay) => {
 };
 
 export default function decorate(block) {
-  const placeholder = block.querySelector('picture');
   const link = block.querySelector('a').href;
   block.textContent = '';
-
-  if (placeholder) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'embed-placeholder';
-    wrapper.innerHTML = '<div class="embed-placeholder-play"><button type="button" title="Play"></button></div>';
-    wrapper.prepend(placeholder);
-    wrapper.addEventListener('click', () => {
-      loadEmbed(block, link, true);
-    });
-    block.append(wrapper);
-  } else {
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some((e) => e.isIntersecting)) {
-        observer.disconnect();
-        loadEmbed(block, link);
-      }
-    });
-    observer.observe(block);
-  }
+  const observer = new IntersectionObserver((entries) => {
+    if (entries.some((e) => e.isIntersecting)) {
+      loadEmbed(block, link);
+    }
+  });
+  observer.observe(block);
 }

--- a/aemedge/blocks/embed/embed.js
+++ b/aemedge/blocks/embed/embed.js
@@ -33,7 +33,6 @@ const embedFacebook = (url) => {
   return embedHTML;
 };
 
-
 const loadEmbed = (block, link, autoplay) => {
   if (block.classList.contains('embed-is-loaded')) {
     return;

--- a/aemedge/blocks/embed/embed.js
+++ b/aemedge/blocks/embed/embed.js
@@ -1,0 +1,234 @@
+/*
+ * Embed Block.
+ * Show videos and social posts directly on your page
+ * https://www.hlx.live/developer/block-collection/embed
+ */
+let delayDone = false;
+
+const loadScript = (url, callback, type) => {
+  const head = document.querySelector('head');
+  const script = document.createElement('script');
+  script.src = url;
+  if (type) {
+    script.setAttribute('type', type);
+  }
+  script.onload = callback;
+  head.append(script);
+  return script;
+};
+
+const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+    <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen=""
+    scrolling="no" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
+    </iframe>
+  </div>`;
+
+const embedTwitter = (url) => {
+  const scripts = document.querySelectorAll('script');
+  scripts.forEach((script) => {
+    const hasTwitterJs = script.src.includes('https://platform.twitter.com/widgets.js');
+    if (hasTwitterJs) {
+      script.remove();
+    }
+  });
+
+  if (delayDone) {
+    loadScript('https://platform.twitter.com/widgets.js');
+  }
+  const embedHTML = `<blockquote class="twitter-tweet"><a href="${url.href}"></a></blockquote>`;
+  return embedHTML;
+};
+
+const embedInstagram = (url, options) => {
+  const scripts = document.querySelectorAll('script');
+  const srcArray = [];
+
+  scripts.forEach((script) => {
+    srcArray.push(script.src);
+  });
+
+  const hasInstagramJs = srcArray.includes('https://www.instagram.com/embed.js');
+
+  if (!hasInstagramJs) {
+    loadScript('https://www.instagram.com/embed.js');
+  }
+
+  const embedHTML = `<blockquote class="instagram-media" ${options ? 'data-instgrm-captioned' : ''} data-instgrm-permalink="${url.href}" data-instgrm-version="14"></blockquote>`;
+  return embedHTML;
+};
+
+const embedTiktok = async (url) => {
+  const response = await fetch(`https://www.tiktok.com/oembed?url=${url.href}`);
+  const nextStep = await response.json();
+  const embedHTML = nextStep.html;
+  const scripts = document.querySelectorAll('script');
+
+  scripts.forEach((script) => {
+    const hasTiktokJs = script.src.includes('https://www.tiktok.com/embed.js');
+    if (hasTiktokJs) {
+      script.remove();
+    }
+  });
+
+  if (delayDone) {
+    loadScript('https://www.tiktok.com/embed.js');
+  }
+
+  return embedHTML;
+};
+
+const embedLoaderSpinner = () => {
+  const span = document.createElement('span');
+  const spanParent = document.createElement('span');
+  spanParent.className = 'loader-parent';
+  span.className = 'loader';
+  spanParent.append(span);
+  return spanParent;
+};
+
+const loadEmbed = (block, link, options) => {
+  if (block.classList.contains('embed-is-loaded')) {
+    return;
+  }
+
+  const EMBEDS_CONFIG = [
+    {
+      match: ['twitter'],
+      embed: embedTwitter,
+    },
+    {
+      match: ['instagram'],
+      embed: embedInstagram,
+    },
+    {
+      match: ['tiktok'],
+      embed: embedTiktok,
+    },
+  ];
+
+  const config = EMBEDS_CONFIG.find((e) => e.match.some((match) => link.includes(match)));
+  const url = new URL(link);
+  if (config) {
+    const isTiktok = config.match[0] === 'tiktok';
+    if (isTiktok) {
+      config.embed(url, options).then((data) => {
+        block.innerHTML = data;
+      });
+    } else {
+      block.innerHTML = config.embed(url, options);
+    }
+    block.classList = `block embed embed-${config.match[0]}`;
+  } else {
+    block.innerHTML = getDefaultEmbed(url);
+    block.classList = 'block embed';
+  }
+  block.classList.add('embed-is-loaded');
+};
+
+const instagramObjects = [];
+
+export default function decorate(block) {
+  function formatHTML() {
+    let embedLink = '';
+    block.innerHTML = block.textContent;
+    const isTwitter = block.innerHTML.includes('twitter');
+    const isTiktok = block.innerHTML.includes('tiktok');
+    const isInstagram = block.innerHTML.includes('instagram');
+
+    if (isTwitter) {
+      const getLinks = block.querySelectorAll('a');
+
+      getLinks.forEach((a) => {
+        const myLink = a.href.includes('status');
+        if (myLink) {
+          embedLink = a.href;
+        }
+      });
+    }
+
+    if (isTiktok) embedLink = block.querySelector('blockquote').getAttribute('cite');
+    if (isInstagram) embedLink = block.querySelector('blockquote').getAttribute('data-instgrm-permalink');
+
+    return embedLink;
+  }
+  const isLink = block.querySelector('a')?.href;
+  const link = !isLink ? formatHTML() : isLink;
+  const placeholder = block.querySelector('picture');
+  const instagram = block.classList.contains('instagram');
+  const preInstagram = block.innerHTML.includes('instagram');
+  const preTwitter = block.innerHTML.includes('twitter');
+  const twitter = block.classList.contains('twitter');
+  const preTiktok = block.innerHTML.includes('tiktok');
+  const tiktok = block.classList.contains('tiktok');
+
+  if (preInstagram && !instagram) {
+    loadEmbed(block);
+    return;
+  }
+
+  block.textContent = '';
+
+  if ((twitter && !delayDone) || (preTwitter && !twitter && !delayDone)) {
+    const embedWrapper = block.closest('.embed-wrapper');
+    const spinner = embedLoaderSpinner();
+
+    embedWrapper.classList.add('twitter-loader');
+    block.classList.add('loading');
+
+    embedWrapper.append(spinner);
+  }
+
+  if ((tiktok && !delayDone) || (preTiktok && !tiktok && !delayDone)) {
+    const embedWrapper = block.closest('.embed-wrapper');
+    const spinner = embedLoaderSpinner();
+
+    embedWrapper.classList.add('tiktok-loader');
+    block.classList.add('loading');
+
+    embedWrapper.append(spinner);
+  }
+
+  if (placeholder) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'embed-placeholder';
+    wrapper.innerHTML = '<div class="embed-placeholder-play"><button title="Play"></button></div>';
+    wrapper.prepend(placeholder);
+    wrapper.addEventListener('click', () => {
+      loadEmbed(block, link, true);
+    });
+    block.append(wrapper);
+  } else if (instagram) {
+    const caption = block.classList.contains('captions');
+    const spinner = embedLoaderSpinner();
+
+    block.classList.add('loading');
+
+    block.append(spinner);
+
+    instagramObjects.push({ instBlock: block, instLink: link, instCaption: caption });
+  } else {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          observer.disconnect();
+
+          loadEmbed(block);
+        }
+      },
+      {
+        rootMargin: `${window.innerHeight * 1.25}px 0px`,
+      },
+    );
+    observer.observe(block);
+  }
+}
+
+export function embedDelayDone() {
+  delayDone = true;
+}
+
+export function instagramDelay() {
+  instagramObjects.forEach((instagramInfo) => {
+    loadEmbed(instagramInfo.instBlock, instagramInfo.instLink, instagramInfo.instCaption);
+  });
+}

--- a/aemedge/blocks/embed/embed.js
+++ b/aemedge/blocks/embed/embed.js
@@ -1,9 +1,7 @@
 /*
- * Embed Block.
- * Show videos and social posts directly on your page
+ * Embed twitter, facebook
  * https://www.hlx.live/developer/block-collection/embed
  */
-let delayDone = false;
 
 const loadScript = (url, callback, type) => {
   const head = document.querySelector('head');
@@ -19,104 +17,43 @@ const loadScript = (url, callback, type) => {
 
 const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
     <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen=""
-    scrolling="no" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
+      scrolling="no" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
     </iframe>
   </div>`;
 
 const embedTwitter = (url) => {
-  const scripts = document.querySelectorAll('script');
-  scripts.forEach((script) => {
-    const hasTwitterJs = script.src.includes('https://platform.twitter.com/widgets.js');
-    if (hasTwitterJs) {
-      script.remove();
-    }
-  });
-
-  if (delayDone) {
-    loadScript('https://platform.twitter.com/widgets.js');
-  }
   const embedHTML = `<blockquote class="twitter-tweet"><a href="${url.href}"></a></blockquote>`;
+  loadScript('https://platform.twitter.com/widgets.js');
   return embedHTML;
 };
 
-const embedInstagram = (url, options) => {
-  const scripts = document.querySelectorAll('script');
-  const srcArray = [];
-
-  scripts.forEach((script) => {
-    srcArray.push(script.src);
-  });
-
-  const hasInstagramJs = srcArray.includes('https://www.instagram.com/embed.js');
-
-  if (!hasInstagramJs) {
-    loadScript('https://www.instagram.com/embed.js');
-  }
-
-  const embedHTML = `<blockquote class="instagram-media" ${options ? 'data-instgrm-captioned' : ''} data-instgrm-permalink="${url.href}" data-instgrm-version="14"></blockquote>`;
+const embedFacebook = (url) => {
+  const embedHTML = `<div class="fb-post" data-href="${url.href}" data-width="auto"></div>`;
+  loadScript('https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2');
   return embedHTML;
 };
 
-const embedTiktok = async (url) => {
-  const response = await fetch(`https://www.tiktok.com/oembed?url=${url.href}`);
-  const nextStep = await response.json();
-  const embedHTML = nextStep.html;
-  const scripts = document.querySelectorAll('script');
 
-  scripts.forEach((script) => {
-    const hasTiktokJs = script.src.includes('https://www.tiktok.com/embed.js');
-    if (hasTiktokJs) {
-      script.remove();
-    }
-  });
-
-  if (delayDone) {
-    loadScript('https://www.tiktok.com/embed.js');
-  }
-
-  return embedHTML;
-};
-
-const embedLoaderSpinner = () => {
-  const span = document.createElement('span');
-  const spanParent = document.createElement('span');
-  spanParent.className = 'loader-parent';
-  span.className = 'loader';
-  spanParent.append(span);
-  return spanParent;
-};
-
-const loadEmbed = (block, link, options) => {
+const loadEmbed = (block, link, autoplay) => {
   if (block.classList.contains('embed-is-loaded')) {
     return;
   }
 
   const EMBEDS_CONFIG = [
     {
+      match: ['facebook'],
+      embed: embedFacebook,
+    },
+    {
       match: ['twitter'],
       embed: embedTwitter,
-    },
-    {
-      match: ['instagram'],
-      embed: embedInstagram,
-    },
-    {
-      match: ['tiktok'],
-      embed: embedTiktok,
     },
   ];
 
   const config = EMBEDS_CONFIG.find((e) => e.match.some((match) => link.includes(match)));
   const url = new URL(link);
   if (config) {
-    const isTiktok = config.match[0] === 'tiktok';
-    if (isTiktok) {
-      config.embed(url, options).then((data) => {
-        block.innerHTML = data;
-      });
-    } else {
-      block.innerHTML = config.embed(url, options);
-    }
+    block.innerHTML = config.embed(url, autoplay);
     block.classList = `block embed embed-${config.match[0]}`;
   } else {
     block.innerHTML = getDefaultEmbed(url);
@@ -125,110 +62,27 @@ const loadEmbed = (block, link, options) => {
   block.classList.add('embed-is-loaded');
 };
 
-const instagramObjects = [];
-
 export default function decorate(block) {
-  function formatHTML() {
-    let embedLink = '';
-    block.innerHTML = block.textContent;
-    const isTwitter = block.innerHTML.includes('twitter');
-    const isTiktok = block.innerHTML.includes('tiktok');
-    const isInstagram = block.innerHTML.includes('instagram');
-
-    if (isTwitter) {
-      const getLinks = block.querySelectorAll('a');
-
-      getLinks.forEach((a) => {
-        const myLink = a.href.includes('status');
-        if (myLink) {
-          embedLink = a.href;
-        }
-      });
-    }
-
-    if (isTiktok) embedLink = block.querySelector('blockquote').getAttribute('cite');
-    if (isInstagram) embedLink = block.querySelector('blockquote').getAttribute('data-instgrm-permalink');
-
-    return embedLink;
-  }
-  const isLink = block.querySelector('a')?.href;
-  const link = !isLink ? formatHTML() : isLink;
   const placeholder = block.querySelector('picture');
-  const instagram = block.classList.contains('instagram');
-  const preInstagram = block.innerHTML.includes('instagram');
-  const preTwitter = block.innerHTML.includes('twitter');
-  const twitter = block.classList.contains('twitter');
-  const preTiktok = block.innerHTML.includes('tiktok');
-  const tiktok = block.classList.contains('tiktok');
-
-  if (preInstagram && !instagram) {
-    loadEmbed(block);
-    return;
-  }
-
+  const link = block.querySelector('a').href;
   block.textContent = '';
-
-  if ((twitter && !delayDone) || (preTwitter && !twitter && !delayDone)) {
-    const embedWrapper = block.closest('.embed-wrapper');
-    const spinner = embedLoaderSpinner();
-
-    embedWrapper.classList.add('twitter-loader');
-    block.classList.add('loading');
-
-    embedWrapper.append(spinner);
-  }
-
-  if ((tiktok && !delayDone) || (preTiktok && !tiktok && !delayDone)) {
-    const embedWrapper = block.closest('.embed-wrapper');
-    const spinner = embedLoaderSpinner();
-
-    embedWrapper.classList.add('tiktok-loader');
-    block.classList.add('loading');
-
-    embedWrapper.append(spinner);
-  }
 
   if (placeholder) {
     const wrapper = document.createElement('div');
     wrapper.className = 'embed-placeholder';
-    wrapper.innerHTML = '<div class="embed-placeholder-play"><button title="Play"></button></div>';
+    wrapper.innerHTML = '<div class="embed-placeholder-play"><button type="button" title="Play"></button></div>';
     wrapper.prepend(placeholder);
     wrapper.addEventListener('click', () => {
       loadEmbed(block, link, true);
     });
     block.append(wrapper);
-  } else if (instagram) {
-    const caption = block.classList.contains('captions');
-    const spinner = embedLoaderSpinner();
-
-    block.classList.add('loading');
-
-    block.append(spinner);
-
-    instagramObjects.push({ instBlock: block, instLink: link, instCaption: caption });
   } else {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((e) => e.isIntersecting)) {
-          observer.disconnect();
-
-          loadEmbed(block);
-        }
-      },
-      {
-        rootMargin: `${window.innerHeight * 1.25}px 0px`,
-      },
-    );
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) {
+        observer.disconnect();
+        loadEmbed(block, link);
+      }
+    });
     observer.observe(block);
   }
-}
-
-export function embedDelayDone() {
-  delayDone = true;
-}
-
-export function instagramDelay() {
-  instagramObjects.forEach((instagramInfo) => {
-    loadEmbed(instagramInfo.instBlock, instagramInfo.instLink, instagramInfo.instCaption);
-  });
 }

--- a/aemedge/blocks/video/video.css
+++ b/aemedge/blocks/video/video.css
@@ -1,36 +1,36 @@
 .video {
     width: unset;
     text-align: center;
-    max-width: 800px;
+    max-width: 560px;
     margin: 32px auto;
   }
-  
+
   .video.lazy-loading {
     /* reserve an approximate space to avoid extensive layout shifts */
     aspect-ratio: 16 / 9;
   }
-  
+
   .video > div {
     display: flex;
     justify-content: center;
   }
-  
+
   .video video {
     max-width: 100%;
   }
-  
+
   .video video[data-loading] {
     /* reserve an approximate space to avoid extensive layout shifts */
     width: 100%;
     aspect-ratio: 16 / 9;
   }
-  
+
   .video .video-placeholder {
     width: 100%;
     aspect-ratio: 16 / 9;
     position: relative;
   }
-  
+
   .video .video-placeholder > * {
     display: flex;
     align-items: center;
@@ -38,13 +38,13 @@
     position: absolute;
     inset: 0;
   }
-  
+
   .video .video-placeholder picture img {
     width: 100%;
     height: 100%;
     object-fit: cover;
   }
-  
+
   .video .video-placeholder-play button {
     box-sizing: border-box;
     position: relative;
@@ -56,7 +56,7 @@
     border-radius: 20px;
     padding: 0;
   }
-  
+
   .video .video-placeholder-play button::before {
     content: "";
     display: block;

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -123,7 +123,7 @@ export function buildVideoBlocks(main) {
         a.replaceWith(videoBlock);
         decorateBlock(videoBlock);
       }
-      if ((a.href.includes('twitter.com') || a.href.includes('facebook.com') || a.href.includes('instagram.com') || a.href.includes('tiktok.com')) && linkTextIncludesHref(a)) {
+      if ((a.href.includes('twitter.com') || a.href.includes('facebook.com') || a.href.includes('instagram.com')) && linkTextIncludesHref(a)) {
         const embedBlock = buildBlock('embed', a.cloneNode(true));
         a.replaceWith(embedBlock);
         decorateBlock(embedBlock);

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -123,7 +123,7 @@ export function buildVideoBlocks(main) {
         a.replaceWith(videoBlock);
         decorateBlock(videoBlock);
       }
-      if (a.href.includes('twitter.com') && linkTextIncludesHref(a)) {
+      if ((a.href.includes('twitter.com') || a.href.includes('facebook.com')) && linkTextIncludesHref(a)) {
         const embedBlock = buildBlock('embed', a.cloneNode(true));
         a.replaceWith(embedBlock);
         decorateBlock(embedBlock);

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -123,6 +123,11 @@ export function buildVideoBlocks(main) {
         a.replaceWith(videoBlock);
         decorateBlock(videoBlock);
       }
+      if (a.href.includes('twitter.com') && linkTextIncludesHref(a)) {
+        const embedBlock = buildBlock('embed', a.cloneNode(true));
+        a.replaceWith(embedBlock);
+        decorateBlock(embedBlock);
+      }
     });
   }
 }

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -123,7 +123,7 @@ export function buildVideoBlocks(main) {
         a.replaceWith(videoBlock);
         decorateBlock(videoBlock);
       }
-      if ((a.href.includes('twitter.com') || a.href.includes('facebook.com')) && linkTextIncludesHref(a)) {
+      if ((a.href.includes('twitter.com') || a.href.includes('facebook.com') || a.href.includes('instagram.com') || a.href.includes('tiktok.com')) && linkTextIncludesHref(a)) {
         const embedBlock = buildBlock('embed', a.cloneNode(true));
         a.replaceWith(embedBlock);
         decorateBlock(embedBlock);


### PR DESCRIPTION
Twitter and Facebook and instagram embed added.

Fix #123 

Test URLs:
FACEBOOK
- Before: https://main--sling--aemsites.aem.page/whatson/sports/college-football/rece-davis-college-gameday-interview
- After: https://123-embedblock--sling--aemsites.aem.page/whatson/sports/college-football/rece-davis-college-gameday-interview

TWITTER
- Before: https://main--sling--aemsites.aem.page/whatson/sports/combat-sports/stream-bkfc-48-live
- After: https://123-embedblock--sling--aemsites.aem.page/whatson/sports/combat-sports/stream-bkfc-48-live

INSTAGRAM, Facebook, Twitter and youtube
- Before: https://main--sling--aemsites.aem.page/whatson/entertainment/holiday/00-charity-movies-shows
- After: https://123-embedblock--sling--aemsites.aem.page/whatson/entertainment/holiday/00-charity-movies-shows