### PR TITLE
made js more specific for different variants of table and few styling…

### DIFF
--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -139,8 +139,23 @@ blockquote {
   table-layout: fixed;
 }
 
-div.section.table-container div.default-content-wrapper {
+div.section.table-container .default-content-wrapper p {
   text-align: center;
+}
+
+div.section.table-container .default-content-wrapper .button-container {
+  text-align: left;
+  background-color: var(--background-color);
+}
+
+div.section.table-container .default-content-wrapper .button-container a {
+  text-align: left;
+  background-color: var(--background-color);
+  border: none;
+}
+
+div.section.table-container .default-content-wrapper .button-container ~ p {
+  text-align: left;
 }
 
 @media (width >= 768px) {

--- a/aemedge/blocks/table/table.js
+++ b/aemedge/blocks/table/table.js
@@ -35,12 +35,15 @@ export default async function decorate(block) {
   });
   block.innerHTML = '';
   block.append(table);
-}
 
-//  adding code for schedule table
-
-setTimeout(() => {
-  const tableRows = document.querySelectorAll('.table-wrapper table tbody tr');
+  let tableRows = '';
+  if (block.classList.contains('schedule')) {
+    const scheduletableRows = block.querySelectorAll('table tbody tr');
+    tableRows = scheduletableRows;
+  } else if (block.classList.contains('playoffs')) {
+    const playoffstableRows = block.querySelectorAll('table tbody tr');
+    tableRows = playoffstableRows;
+  }
   let trcount = 0;
   tableRows.forEach((row) => {
     const cells = row.querySelectorAll('td');
@@ -57,4 +60,4 @@ setTimeout(() => {
     }
     trcount += 1;
   });
-});
+}


### PR DESCRIPTION
Fix #140 

Test URLs:
- Before: https://main--sling--aemsites.aem.page/whatson/sports/nhl/000-nhl-stanley-cup-playoffs-schedule-sling
- After: https://140-table-fixes--sling--aemsites.aem.page/whatson/sports/nhl/000-nhl-stanley-cup-playoffs-schedule-sling

Modified js to more specific to table variants, Now We can have two different variants on same page.