### PR TITLE
adding blog primary , secondary button styles

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -227,20 +227,37 @@ export function decorateButtons(element) {
           up.classList.add('button-container');
           a.append(linkTextEl);
         }
+
         // primary buttons in whatson pages
-        if (window.location?.pathname?.includes('/whatson/')) {
+        if (getPageType() === 'blog') {
+          const threeup = a.parentElement.parentElement.parentElement;
+          // primary button
           if (
             up.childNodes.length === 1
             && up.tagName === 'STRONG'
-            && twoup.childNodes.length === 1
-            && (twoup.tagName === 'P' || twoup.tagName === 'DIV')
-            // http://localhost:3000/whatson/freestream/tate-mcrae-vevo-extended-play
+            && threeup.childNodes.length === 1
+            && (twoup && twoup.tagName === 'DEL')
+            && (threeup.tagName === 'P' || threeup.tagName === 'DIV')
             && (
-              !twoup.previousElementSibling?.innerHTML.startsWith('<strong><a href="')
-              && !twoup.nextElementSibling?.innerHTML.startsWith('<strong><a href="'))) {
+              !threeup.previousElementSibling?.innerHTML.startsWith('<strong><a href="')
+              && !threeup.nextElementSibling?.innerHTML.startsWith('<strong><a href="'))) {
             a.className = 'button primary';
             if (a.href.includes('/cart/')) a.target = '_blank';
-            twoup.classList.add('button-container');
+            threeup.classList.add('button-container');
+          }
+          // secondary button
+          if (
+            up.childNodes.length === 1
+            && up.tagName === 'EM'
+            && threeup.childNodes.length === 1
+            && (twoup && twoup.tagName === 'DEL')
+            && (threeup.tagName === 'P' || threeup.tagName === 'DIV')
+            && (
+              !threeup.previousElementSibling?.innerHTML.startsWith('<strong><a href="')
+              && !threeup.nextElementSibling?.innerHTML.startsWith('<strong><a href="'))) {
+            a.className = 'button secondary';
+            if (a.href.includes('/cart/')) a.target = '_blank';
+            threeup.classList.add('button-container');
           }
         } else if (
           up.childNodes.length === 1


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #230 

Test URLs:
- Before: https://main--sling--aemsites.aem.page/whatson/sports/college-football/watch-colorado-football-live
- After: https://230-buttons--sling--aemsites.aem.page/whatson/sports/college-football/watch-colorado-football-live
- Before: https://main--sling--aemsites.aem.page/
- After: https://230-buttons--sling--aemsites.aem.page/
Note - After this PR approved , we need to make the following changes

- [ ] Format the Link text in Try Sling Fragment s
- [ ] Tweak the import script so that the buttons will be imported with the new formatting