### PR TITLE
Tabes: no need for section breaks

### DIFF
--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -135,10 +135,6 @@ blockquote {
   table-layout: fixed;
 }
 
-div.section.table-container .default-content-wrapper p {
-  text-align: center;
-}
-
 div.section.table-container .default-content-wrapper .button-container {
   text-align: left;
   background-color: var(--background-color);
@@ -164,12 +160,7 @@ div.section.table-container .default-content-wrapper .button-container ~ p {
 
   .playoffs.table, .schedule.table{
     margin-left: 8px;
-  }
-
-  .playoffs.table table,
-  .schedule.table table {
-    width: 66%;
-    margin: 0 auto 0 17%;
+    margin-bottom: 48px;
   }
 }
 


### PR DESCRIPTION
No need for horizontal line in between tables now.

Fix #245 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/whatson/sports/general-sports/live-sports-schedules-sling-tv
- After: https://245tables--sling--aemsites.aem.live/whatson/sports/general-sports/live-sports-schedules-sling-tv

- Before: https://main--sling--aemsites.aem.page/whatson/sports/baseball/watch-little-league-world-series-live
- After: https://245tables--sling--aemsites.aem.page/whatson/sports/baseball/watch-little-league-world-series-live

- Before: https://main--sling--aemsites.aem.page/whatson/sports/baseball/mlb-network-free-preview
- After: https://245tables--sling--aemsites.aem.page/whatson/sports/baseball/mlb-network-free-preview
