### PR TITLE
accordion width fix

### DIFF
--- a/aemedge/blocks/accordion/accordion.css
+++ b/aemedge/blocks/accordion/accordion.css
@@ -110,9 +110,7 @@
   }
 
   .accordion-wrapper {
-    margin: 0 auto 4rem;
-    width: 66%;
-    padding-left: 4rem;
+    margin: 1.25rem auto 4rem;
   }
 
   .tabs-panel .accordion-wrapper {


### PR DESCRIPTION
Adjust width of accordion for when there is no section break.

Fix #256 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/
- After: https://256-accordian--sling--aemsites.aem.live/

- Before: https://main--sling--aemsites.aem.page/whatson/sports/college-football/college-football-national-championship-sling-tv
- After: https://256-accordian--sling--aemsites.aem.page/whatson/sports/college-football/college-football-national-championship-sling-tv

Testing: Check that the accordion on the home page hasn't changed.
