### PR TITLE
Headerchanges

### DIFF
--- a/aemedge/blocks/header/header.js
+++ b/aemedge/blocks/header/header.js
@@ -128,19 +128,18 @@ export default async function decorate(block) {
   const navMeta = getMetadata('nav');
   let navPath = '/aemedge/nav';
   const headerType = getMetadata('headertype');
-  if (headerType === 'header1') {
-    navPath = '/drafts/ritwik/header1';
-    /*const headerWrapper = document.querySelector('.header-wrapper');
+  if (headerType === 'design1') {
+    navPath = '/aemedge/navdesign1';
+    /* const headerWrapper = document.querySelector('.header-wrapper');
     // Remove the 'height' property from the element's inline styles
     if (headerWrapper) {
       headerWrapper.style.removeProperty('height');
-    }*/
-  } else if ( headerType === 'header2' ) {
-    navPath = '/drafts/ritwik/header2';
+    } */
+  } else if (headerType === 'design2') {
+    navPath = '/aemedge/navdesign2';
+  } else {
+    navPath = navMeta ? new URL(navMeta).pathname : '/aemedge/nav';
   }
-  else {
-        navPath = navMeta ? new URL(navMeta).pathname : '/aemedge/nav';
-    }
   const fragment = await loadFragment(navPath);
   let topnavSection;
   if (fragment.childElementCount === 4) {

--- a/aemedge/blocks/header/header.js
+++ b/aemedge/blocks/header/header.js
@@ -127,14 +127,18 @@ export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
   let navPath = '/aemedge/nav';
-  const headerType = getMetadata('headertype');
-  if (headerType === 'design1') {
+  const navMetaPath = navMeta ? new URL(navMeta).pathname : '';
+
+  if (navMetaPath.includes('programming') || navMetaPath.includes('watch') || navMetaPath.includes('deals')) {
     navPath = '/aemedge/navdesign1';
-  } else if (headerType === 'design2') {
+  } else if (navMetaPath.includes('international')) {
     navPath = '/aemedge/navdesign2';
+  } else if (navMetaPath.includes('latino')) {
+    navPath = '/aemedge/navdesign3';
   } else {
-    navPath = navMeta ? new URL(navMeta).pathname : '/aemedge/nav';
+    navPath = '/aemedge/nav';
   }
+
   const fragment = await loadFragment(navPath);
   let topnavSection;
   if (fragment.childElementCount === 4) {

--- a/aemedge/blocks/header/header.js
+++ b/aemedge/blocks/header/header.js
@@ -126,7 +126,21 @@ function moveTopNav(e, topNavSection, navSections) {
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta).pathname : '/aemedge/nav';
+  let navPath = '/aemedge/nav';
+  const headerType = getMetadata('headertype');
+  if (headerType === 'header1') {
+    navPath = '/drafts/ritwik/header1';
+    /*const headerWrapper = document.querySelector('.header-wrapper');
+    // Remove the 'height' property from the element's inline styles
+    if (headerWrapper) {
+      headerWrapper.style.removeProperty('height');
+    }*/
+  } else if ( headerType === 'header2' ) {
+    navPath = '/drafts/ritwik/header2';
+  }
+  else {
+        navPath = navMeta ? new URL(navMeta).pathname : '/aemedge/nav';
+    }
   const fragment = await loadFragment(navPath);
   let topnavSection;
   if (fragment.childElementCount === 4) {

--- a/aemedge/blocks/header/header.js
+++ b/aemedge/blocks/header/header.js
@@ -130,11 +130,6 @@ export default async function decorate(block) {
   const headerType = getMetadata('headertype');
   if (headerType === 'design1') {
     navPath = '/aemedge/navdesign1';
-    /* const headerWrapper = document.querySelector('.header-wrapper');
-    // Remove the 'height' property from the element's inline styles
-    if (headerWrapper) {
-      headerWrapper.style.removeProperty('height');
-    } */
   } else if (headerType === 'design2') {
     navPath = '/aemedge/navdesign2';
   } else {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

based on the "nav" page level metadata we can control the which header to show. 
Sports/News/entertainment/Deals/Freestream share the same header. Design1
International and latino are similar - Design2
rewards - Design3

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--sling--aemsites.aem.page/drafts/ritwik/test
- After: https://headerchanges--sling--aemsites.aem.page/drafts/ritwik/test 
Design1
https://headerchanges--sling--aemsites.aem.page/drafts/ritwik/test1
Design2
