### PR TITLE
Section banner refactor w/ bg images

### DIFF
--- a/aemedge/blocks/columns/columns.css
+++ b/aemedge/blocks/columns/columns.css
@@ -8,10 +8,6 @@
   flex-direction: column;
 }
 
-.columns > div > div {
-  order: 1;
-}
-
 .columns.icons > div {
   display: flex;
   flex-direction: row;
@@ -25,142 +21,196 @@
   width: 100%;
 }
 
-.columns span.icon img {
-  width: 100%;
-}
-
-.columns > div > .columns-img-col {
-  order: 0;
-}
-
-.columns > div > .columns-img-col img {
-  display: block;
-}
-
-.columns span.icon {
-  display: inline-block;
-  height: 24px;
-  width: 24px;
-}
-
-.columns.icons {
-  place-content: normal center;
-  align-items: center;
-  opacity: 0.6;
-  max-width: 640px;
-  margin: 0 auto;
-}
-
-.columns.icons span {
-  display: flex;
-  align-items: center;
-  margin: 20px;
-}
-
-.columns.icons span.icon {
-  display: unset;
-}
-
-.columns.icons span.icon img {
-  height: 20px;
-  width: 80px;
-}
-
-.international .default-content-wrapper h1{
-  font-size: 2.1rem;
-  margin-bottom: 30px;
-}
-
-.international .columns-container .default-content-wrapper {
-  h1,h2 {
-    font-size: 1.5rem;
-    margin-bottom: 30px;
-    text-align: center;
-  }
-}
-
-.international .columns.block div .columns-img-col img{
-  width: 50vw;
-  height: auto;
-  cursor: pointer;
-}
-
-.international .columns.block .columns-img-col{
-  display: flex;
-  justify-content: center;
-}
-
-@media (width >= 768px) {
-  .columns > div {
-    flex-direction: unset;
-    gap: 8%;
-  }
-
-  .tabs-panel .columns > div {
-    flex-direction: column;
-  }
-
-  .columns-img-col .button-container a{
+.banner .columns {
+  picture {
+    flex: 1 1 0;
     display: flex;
+    -webkit-box-pack: center;
     justify-content: center;
+    -webkit-box-align: center;
+    align-items: center;
+
+    img {
+      max-width: 80%;
+    }
   }
 
+  > div {
+    position: relative;
+    width: 100%;
+    padding: 3rem 0;
+    align-items: center;
 
-  .international .columns.columns-1-cols div .columns-img-col img{
-    width: 16.66vw;
-    max-width: 194.7px;
-    height: auto;
-  }
-
-  .international .columns.columns-1-cols div{
-    display: flex;
-    justify-content: center;
-  }
-
-  .international .columns.columns-3-cols div .columns-img-col img{
-    width: 16.5vw;
-    max-width: 192.7px;
-    height: auto;
-  }
-
-  .international .columns.columns-3-cols div {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    margin-bottom: 50px;
-  }
-
-  .international .columns.columns-4-cols div{
-    display: flex;
-    justify-content: center;
-    gap: 4%;
-    margin: auto;
-  }
-
-  .international .columns.columns-4-cols div .columns-img-col img{
-    width: 16.66vw;
-    max-width: 194.7px;
-    height: auto;
-  }
-
-
-}
-
-@media (width >=1024px) {
-  .international .columns.icons span.icon img {
-    width: 96px;
-    height: 36px;
-    padding-bottom: 24px;
+    > div {
+      margin-top: 1rem;
+    }
   }
 }
 
-@media (width >=1200px) {
-  .tabs.columns {
-    width: 88%;
+  .columns span.icon img {
+    width: 100%;
+  }
+
+  .columns > div > .columns-img-col {
+    order: 0;
+  }
+
+  .columns > div > .columns-img-col img {
+    display: block;
+  }
+
+  .columns span.icon {
+    display: inline-block;
+    height: 24px;
+    width: 24px;
+  }
+
+  .columns.icons {
+    place-content: normal center;
+    align-items: center;
+    opacity: 0.6;
+    max-width: 640px;
     margin: 0 auto;
   }
 
-  .tabs-panel .columns > div {
-    flex-direction: row;
+  .columns.icons span {
+    display: flex;
+    align-items: center;
+    margin: 20px;
   }
-}
+
+  .columns.icons span.icon {
+    display: unset;
+  }
+
+  .columns.icons span.icon img {
+    height: 20px;
+    width: 80px;
+  }
+
+  .international .default-content-wrapper h1{
+    font-size: 2.1rem;
+    margin-bottom: 30px;
+  }
+
+  .international .columns-container .default-content-wrapper {
+    h1,h2 {
+      font-size: 1.5rem;
+      margin-bottom: 30px;
+      text-align: center;
+    }
+  }
+
+  .international .columns.block div .columns-img-col img{
+    width: 50vw;
+    height: auto;
+    cursor: pointer;
+  }
+
+  .international .columns.block .columns-img-col{
+    display: flex;
+    justify-content: center;
+  }
+
+  @media (width >= 768px) {
+    .columns > div {
+      flex-direction: unset;
+      gap: 8%;
+    }
+
+    .banner .columns > div {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .tabs-panel .columns > div {
+      flex-direction: column;
+    }
+
+    .columns-img-col .button-container a{
+      display: flex;
+      justify-content: center;
+    }
+
+
+    .international .columns.columns-1-cols div .columns-img-col img{
+      width: 16.66vw;
+      max-width: 194.7px;
+      height: auto;
+    }
+
+    .international .columns.columns-1-cols div{
+      display: flex;
+      justify-content: center;
+    }
+
+    .international .columns.columns-3-cols div .columns-img-col img{
+      width: 16.5vw;
+      max-width: 192.7px;
+      height: auto;
+    }
+
+    .international .columns.columns-3-cols div {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      margin-bottom: 50px;
+    }
+
+    .international .columns.columns-4-cols div{
+      display: flex;
+      justify-content: center;
+      gap: 4%;
+      margin: auto;
+    }
+
+    .international .columns.columns-4-cols div .columns-img-col img{
+      width: 16.66vw;
+      max-width: 194.7px;
+      height: auto;
+    }
+
+
+  }
+
+  @media (width >=1024px) {
+    .international .columns.icons span.icon img {
+      width: 96px;
+      height: 36px;
+      padding-bottom: 24px;
+    }
+
+    .banner .columns > div {
+      flex-direction: unset;
+      gap: 8%;
+      padding: 0;
+
+      > div:first-child {
+        display: flex;
+        flex-direction: column;
+        padding: 5rem 4rem;
+        justify-content: center;
+        align-items: flex-start;
+        flex: 2 1 0;
+      }
+
+      > div:last-child {
+        flex: 1 1 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+  }
+
+  @media (width >=1200px) {
+    .tabs.columns {
+      width: 88%;
+      margin: 0 auto;
+    }
+
+    .tabs-panel .columns > div {
+      flex-direction: row;
+    }
+  }
+

--- a/aemedge/blocks/columns/columns.css
+++ b/aemedge/blocks/columns/columns.css
@@ -47,6 +47,25 @@
   }
 }
 
+.banner.small .columns {
+  picture {
+    justify-content: left;
+  }
+
+    > div {
+        padding: 1rem;
+
+      > div {
+        margin-top: 0;
+      }
+    }
+
+  .section {
+    padding: 0;
+    margin: 0;
+  }
+}
+
   .columns span.icon img {
     width: 100%;
   }
@@ -174,6 +193,11 @@
   }
 
   @media (width >=1024px) {
+    .columns.icons span.icon img {
+      height: 36px;
+      width: 96px;
+    }
+
     .international .columns.icons span.icon img {
       width: 96px;
       height: 36px;
@@ -186,20 +210,22 @@
       padding: 0;
 
       > div:first-child {
-        display: flex;
-        flex-direction: column;
         padding: 5rem 4rem;
-        justify-content: center;
-        align-items: flex-start;
         flex: 2 1 0;
       }
 
       > div:last-child {
         flex: 1 1 0;
         display: flex;
-        justify-content: center;
+        justify-content: right;
         align-items: center;
       }
+    }
+
+    .banner.small .columns > div { /* stylelint-disable-line */
+        > div:first-child {
+            padding: 1rem 0 2rem;
+        }
     }
   }
 

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -160,11 +160,12 @@ export function buildMultipleButtons(main) {
   });
 }
 
+/* we shouldn't need this anymore
 export function buildCtaBanners(main) {
   // cta banner
-  const columns = main.querySelectorAll('.section.cta-banner div.columns-wrapper');
-  columns.forEach((column) => {
-    const pictures = column.parentElement.querySelectorAll('p picture');
+  const sections = main.querySelectorAll('.section.banner2');
+  sections.forEach((section) => {
+    const pictures = section.querySelectorAll('p picture');
     if (pictures) {
       const images = [];
       pictures.forEach((picture, idx) => {
@@ -177,10 +178,88 @@ export function buildCtaBanners(main) {
         images.push(image);
         pTag.remove();
       });
-      const blogHero = buildBlock('blog-hero', { elems: images });
-      column.parentElement.prepend(blogHero);
-      decorateBlock(blogHero);
+      const banner = buildBlock('banner', { elems: images });
+      section.append(banner);
+      decorateBlock(banner);
     }
+  });
+}
+
+ */
+
+/**
+ * Sets an optimized background image for a given section element.
+ * This function takes into account the device's viewport width and device pixel ratio
+ * to choose the most appropriate image from the provided breakpoints.
+ *
+ * @param {HTMLElement} section - The section element to which the background image will be applied.
+ * @param {string} bgImage - The base URL of the background image.
+ * @param {Array<{width: string, media?: string}>} [breakpoints=[
+ *  { width: '450' },
+ *   { media: '(min-width: 450px)', width: '750' },
+ *   { media: '(min-width: 768px)', width: '1024' },
+ *   { media: '(min-width: 1024px)', width: '1600' },
+ *   { media: '(min-width: 1600px)', width: '2200' },
+ * ]] - An array of breakpoint objects. Each object contains a `width` which is the width of the
+ * image to request, and an optional `media` which is a media query string indicating when this
+ * breakpoint should be used.
+ */
+
+const resizeListeners = new WeakMap();
+function getBackgroundImage(section) {
+  // look for "background" values in the section metadata
+  const bgImages = section.dataset.background.split(',');
+  if (bgImages.length === 1) {
+    return bgImages[0].trim();
+  } // if there are 2 images, first is for desktop and second is for mobile
+  return (window.innerWidth > 1024 && bgImages.length === 2)
+    ? bgImages[0].trim() : bgImages[1].trim();
+}
+
+function createOptimizedBackgroundImage(section, breakpoints = [
+  { width: '450' },
+  { media: '(min-width: 450px)', width: '768' },
+  { media: '(min-width: 768px)', width: '1024' },
+  { media: '(min-width: 1024px)', width: '1600' },
+  { media: '(min-width: 1600px)', width: '2000' },
+]) {
+  const updateBackground = () => {
+    const bgImage = getBackgroundImage(section);
+    const url = new URL(bgImage, window.location.href);
+    const pathname = encodeURI(url.pathname);
+
+    const matchedBreakpoints = breakpoints.filter(
+      (br) => !br.media || window.matchMedia(br.media).matches,
+    );
+    // If there are any matching breakpoints, pick the one with the highest resolution
+    const matchedBreakpoint = matchedBreakpoints.reduce(
+      (acc, curr) => (parseInt(curr.width, 10) > parseInt(acc.width, 10) ? curr : acc),
+      breakpoints[0],
+    );
+
+    const adjustedWidth = matchedBreakpoint.width * window.devicePixelRatio;
+    section.style.backgroundImage = `url(${pathname}?width=${adjustedWidth}&format=webply&optimize=highest)`;
+    section.style.backgroundSize = 'cover';
+  };
+
+  if (resizeListeners.has(section)) {
+    window.removeEventListener('resize', resizeListeners.get(section));
+  }
+
+  resizeListeners.set(section, updateBackground);
+  window.addEventListener('resize', updateBackground);
+  updateBackground();
+}
+
+/**
+ * Finds all sections in the main element of the document
+ * that require adding a background image
+ * @param {Element} main
+ */
+
+function decorateStyledSections(main) {
+  Array.from(main.querySelectorAll('.section[data-background]')).forEach((section) => {
+    createOptimizedBackgroundImage(section);
   });
 }
 
@@ -403,7 +482,8 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
-  buildCtaBanners(main);
+  // buildCtaBanners(main);
+  decorateStyledSections(main);
   buildSpacer(main);
   decorateLinkedImages();
 }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -163,9 +163,9 @@ export function buildMultipleButtons(main) {
 /* we shouldn't need this anymore
 export function buildCtaBanners(main) {
   // cta banner
-  const sections = main.querySelectorAll('.section.banner2');
-  sections.forEach((section) => {
-    const pictures = section.querySelectorAll('p picture');
+  const columns = main.querySelectorAll('.section.cta-banner div.columns-wrapper');
+  columns.forEach((column) => {
+    const pictures = column.parentElement.querySelectorAll('p picture');
     if (pictures) {
       const images = [];
       pictures.forEach((picture, idx) => {
@@ -178,9 +178,9 @@ export function buildCtaBanners(main) {
         images.push(image);
         pTag.remove();
       });
-      const banner = buildBlock('banner', { elems: images });
-      section.append(banner);
-      decorateBlock(banner);
+      const blogHero = buildBlock('blog-hero', { elems: images });
+      column.parentElement.prepend(blogHero);
+      decorateBlock(blogHero);
     }
   });
 }

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -401,50 +401,25 @@ main .section {
 }
 
 /* CTA Banner Section */
-.section.cta-banner {
+
+.section.banner {
   position: relative;
-  text-align: center;
   color: #fff;
   margin: 0;
-  height: fit-content;
+  background-position: center;
+
+  .buttons-container {
+    text-align: center;
+  }
 }
 
-.section.cta-banner .section {
-  padding: 0;
-}
-
-.section.cta-banner .columns > div {
-  width: unset;
-}
-
-.section.cta-banner .columns-wrapper {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  flex: 2 1 0%;
-  padding: 1.25rem;
-  justify-content: flex-start;
-  align-items: center;
-  box-sizing: border-box;
-  width: 100%;
-  color: #f5f5f6;
-  height: 350px;
-  overflow: hidden;
-}
-
-.section.cta-banner .columns.block {
-  width: 100%;
-  height: fit-content;
-}
-
-.section.cta-banner .blog-hero picture {
+.section.banner .blog-hero picture {
   width: 100%;
   height: 350px;
   overflow: hidden;
 }
 
-.section.cta-banner .blog-hero img {
+.section.banner .blog-hero img {
   box-sizing: border-box;
   height: 100%;
   width: 100%;
@@ -759,11 +734,10 @@ margin:0 auto;
 
 @media (width >=1024px) {
   /* CTA Banner Section */
-  .section.cta-banner .columns-wrapper {
-    padding: 5rem 6.25rem;
-    -webkit-box-pack: center;
-    justify-content: center;
-    align-items: flex-start;
+  .section.banner {
+    .buttons-container {
+      text-align: left;
+    }
   }
 
   .section.package-cards-container .columns.block > div {


### PR DESCRIPTION
I don't think we need "cta-banner" as a section style anymore but I commented out the function for now just in case. 

Fix #313

Test URLs:
- Before: https://main--sling--aemsites.aem.page/drafts/chelms/sectionbanners
- After: https://313-sectioncta--sling--aemsites.aem.page/drafts/chelms/sectionbanners

There are 2 section styles here; the default one with just "banner" as the style (which is considered "medium" on the live site) and one that is "banner, small" to match their shorter version of banner.

Library page also created. https://main--sling--aemsites.aem.page/tools/sidekick/library/library.html?plugin=blocks&path=/library/blocks/banner&index=0