### PR TITLE
317 fragments banner full width fix

### DIFF
--- a/aemedge/blocks/columns/columns.css
+++ b/aemedge/blocks/columns/columns.css
@@ -37,13 +37,11 @@
 
   > div {
     position: relative;
-    width: 100%;
-    padding: 3rem 0;
     align-items: center;
+  }
 
-    > div {
-      margin-top: 1rem;
-    }
+  &:first-child {
+    padding: 3rem 1.5rem;
   }
 }
 
@@ -52,19 +50,19 @@
     justify-content: left;
   }
 
-    > div {
-        padding: 1rem;
-
       > div {
         margin-top: 0;
       }
+
+  &:first-child {
+    padding: 1.5rem;
+  }
     }
 
   .section {
     padding: 0;
     margin: 0;
   }
-}
 
   .columns span.icon img {
     width: 100%;
@@ -207,10 +205,9 @@
     .banner .columns > div {
       flex-direction: unset;
       gap: 8%;
-      padding: 0;
+      padding: 1rem 0 2rem 3.5rem;
 
       > div:first-child {
-        padding: 5rem 4rem;
         flex: 2 1 0;
       }
 
@@ -223,9 +220,7 @@
     }
 
     .banner.small .columns > div { /* stylelint-disable-line */
-        > div:first-child {
-            padding: 1rem 0 2rem;
-        }
+      padding: 1rem 2rem 2rem 2.5rem;
     }
   }
 

--- a/aemedge/blocks/marquee/marquee.css
+++ b/aemedge/blocks/marquee/marquee.css
@@ -1,4 +1,3 @@
-
 .marquee.block {
     color: var(--clr-white);
     position: relative;

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -388,6 +388,11 @@ main .section {
   margin: 64px 0;
 }
 
+.section > .default-content-wrapper > p.fragment-wrapper {
+  margin: 0;
+}
+
+
 /* FAQ Section */
 .section.tabs-container.accordion-container .default-content-wrapper {
   text-align: center;
@@ -401,12 +406,14 @@ main .section {
 }
 
 /* CTA Banner Section */
-
 .section.banner {
   position: relative;
   color: #fff;
   margin: 0;
+  padding: 0;
   background-position: center;
+
+
 
   .buttons-container {
     text-align: center;
@@ -737,6 +744,13 @@ margin:0 auto;
   .section.banner {
     .buttons-container {
       text-align: left;
+    }
+  }
+
+
+  section > .default-content-wrapper > p.fragment-wrapper {
+    .section.banner {
+      padding: 0 36px 0 0;
     }
   }
 


### PR DESCRIPTION
I took the button-section fragments out of the banner fragments to prevent double nested sections.

Fix #317 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/
- After: https://317-fragmentwidth--sling--aemsites.aem.live/

- Before: https://main--sling--aemsites.aem.page/
- After: https://317-fragmentwidth--sling--aemsites.aem.page/

- Before: https://main--sling--aemsites.aem.page/drafts/chelms/sectionbanners
- After: https://317-fragmentwidth--sling--aemsites.aem.page/drafts/chelms/sectionbanners