### PR TITLE
adding launch.js into delayed

### DIFF
--- a/aemedge/scripts/delayed.js
+++ b/aemedge/scripts/delayed.js
@@ -1,7 +1,30 @@
 // eslint-disable-next-line import/no-cycle
 import { sampleRUM } from './aem.js';
 
+const loadScript = (url, attrs) => {
+  const head = document.querySelector('head');
+  const script = document.createElement('script');
+  script.src = url;
+  if (attrs) {
+    // eslint-disable-next-line no-restricted-syntax, guard-for-in
+    for (const attr in attrs) {
+      script.setAttribute(attr, attrs[attr]);
+    }
+  }
+  head.append(script);
+  return script;
+};
+
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
-// add more delayed functionality here
+// adding launch.js to all but prod so as not to interfere with prod statistics
+// if they need it, uncomment it after go live.
+
+if (window.location.host.endsWith('.page') || window.location.host.startsWith('localhost')) {
+  loadScript('https://assets.adobedtm.com/f4211b096882/26f71ad376c4/launch-b69ac51c7dcd-development.min.js');
+} else if (window.location.host.startsWith('www.sling.com')) {
+  // loadScript('https://assets.adobedtm.com/f4211b096882/26f71ad376c4/launch-c846c0e0cbc6.min.js');
+} else if (window.location.host.startsWith('www.b.sling.com')) {
+  loadScript('https://assets.adobedtm.com/f4211b096882/26f71ad376c4/launch-6367a8aeb307-staging.min.js');
+}


### PR DESCRIPTION
Per Amol, commenting out the Prod script for now since we've been told the blog doesn't track these things.

Fix #348 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/whatson
- After: https://348-launchscripts--sling--aemsites.aem.live/whatson

- Before: https://main--sling--aemsites.aem.live/whatson/freestream/stream-free-horror-movies
- After: https://348-launchscripts--sling--aemsites.aem.live/whatson/freestream/stream-free-horror-movies

The .page should load /launch-b69ac51c7dcd-development.min.js, 
The www.b.sling.com should load /launch-6367a8aeb307-staging.min.js (but you can't see this until after this is merged).
All the boxed in stuff is what you will see now:
![image](https://github.com/user-attachments/assets/1aec0a12-82e7-4601-8d67-df26cc6406d9)
