### PR TITLE
fix section regression + cleanup

### DIFF
--- a/aemedge/scripts/aem.js
+++ b/aemedge/scripts/aem.js
@@ -515,14 +515,6 @@ function decorateSections(main) {
             .filter((style) => style)
             .map((style) => toClassName(style.trim()));
           styles.forEach((style) => section.classList.add(style));
-        } else if (key === 'background') {
-          const pic = sectionMeta.querySelector('picture img');
-          if (pic) {
-            const imageSrc = pic.src;
-            section.style.backgroundImage = `url(${imageSrc})`;
-            section.style.backgroundRepeat = 'no-repeat';
-            section.style.backgroundSize = 'cover';
-          }
         } else {
           section.dataset[toCamelCase(key)] = meta[key];
         }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -160,33 +160,6 @@ export function buildMultipleButtons(main) {
   });
 }
 
-/* we shouldn't need this anymore
-export function buildCtaBanners(main) {
-  // cta banner
-  const columns = main.querySelectorAll('.section.cta-banner div.columns-wrapper');
-  columns.forEach((column) => {
-    const pictures = column.parentElement.querySelectorAll('p picture');
-    if (pictures) {
-      const images = [];
-      pictures.forEach((picture, idx) => {
-        const pTag = picture.parentElement;
-        const image = createTag('div', { class: 'background-image' });
-        if (idx === 0) picture.classList.add('desktop');
-        if (idx === 1) picture.classList.add('mobile');
-        if (pictures.length === 1) picture.classList.add('mobile');
-        image.append(picture);
-        images.push(image);
-        pTag.remove();
-      });
-      const blogHero = buildBlock('blog-hero', { elems: images });
-      column.parentElement.prepend(blogHero);
-      decorateBlock(blogHero);
-    }
-  });
-}
-
- */
-
 /**
  * Sets an optimized background image for a given section element.
  * This function takes into account the device's viewport width and device pixel ratio
@@ -482,7 +455,6 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
-  // buildCtaBanners(main);
   decorateStyledSections(main);
   buildSpacer(main);
   decorateLinkedImages();


### PR DESCRIPTION
background images in sections are again using the correct optimized rendition images.

![image](https://github.com/user-attachments/assets/ee2e1c42-0997-43ed-86e6-e042dfbc589d)


Fix #353 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/
- After: https://353-sectionbgfix--sling--aemsites.aem.live/

This shouldn't change
- Before: https://main--sling--aemsites.aem.live/rewards
- After: https://353-sectionbgfix--sling--aemsites.aem.live/rewards



