### PR TITLE
link color update for scores

### DIFF
--- a/aemedge/templates/blog-article/blog-article.css
+++ b/aemedge/templates/blog-article/blog-article.css
@@ -19,10 +19,10 @@
     line-height: 1.5em;
 }
 
-.blog-article p a,
-.blog-article li a,
-.blog-article .auth-name a {
-    color: #006cdf;
+.blog-article {
+    h1 a, h2 a, h3 a, h4 a, h5 a, p a, li a, .auth-name a {
+        color: #0076ab;
+    }
 }
 
 .blog-article .icon.award {


### PR DESCRIPTION
accessibility score is improved slightly with the color update, but won't be perfect unless Sling allows us to use underlines for links. We can fight for that another day.

Fix #360

Test URLs:
- Before: https://main--sling--aemsites.aem.live/whatson/sports/general-sports/live-sports-schedules-sling-tv
- After: https://360-linkcolor--sling--aemsites.aem.live/whatson/sports/general-sports/live-sports-schedules-sling-tv

- Before: https://main--sling--aemsites.aem.live/whatson/sports/baseball/stream-mlb-postseason-games-live-sling-tv
- After: https://360-linkcolor--sling--aemsites.aem.live/whatson/sports/baseball/stream-mlb-postseason-games-live-sling-tv

- Before: https://main--sling--aemsites.aem.live/whatson/entertainment/documentary-and-news/2024-election-dates
- After: https://360-linkcolor--sling--aemsites.aem.live/whatson/entertainment/documentary-and-news/2024-election-dates


