### PR TITLE
blog category width fix

### DIFF
--- a/aemedge/blocks/category/category.css
+++ b/aemedge/blocks/category/category.css
@@ -10,14 +10,6 @@ main .section.category-container {
   width: 83%;
   margin: 0 auto;
   text-align: center;
-
-  h1 a, h2 a, h3 a, h4 a, p a {
-    color: #0076ab;
-
-    &:hover {
-      color: var(--link-hover-color);
-    }
-  }
 }
 
 .category-container .default-content-wrapper h3 {

--- a/aemedge/blocks/category/category.css
+++ b/aemedge/blocks/category/category.css
@@ -10,6 +10,14 @@ main .section.category-container {
   width: 83%;
   margin: 0 auto;
   text-align: center;
+
+  h1 a, h2 a, h3 a, h4 a, p a {
+    color: #0076ab;
+
+    &:hover {
+      color: var(--link-hover-color);
+    }
+  }
 }
 
 .category-container .default-content-wrapper h3 {
@@ -131,7 +139,7 @@ main .section.category-container {
   line-height: 21px;
 
   a {
-    color: #0078aa;
+    color: #0076ab;
  }
 
   a:hover {
@@ -270,7 +278,7 @@ main .section.category-container {
 
 @media screen and (width >=768px) {
   .category-container .default-content-wrapper {
-    width: 33%;
+    width: 50%;
   }
 
   .section > div.category-wrapper {


### PR DESCRIPTION
Added same color changes as we did to the blog article pages.
Also fixed width of the text content to 50% instead of 33%.
Fix #365

Test URLs:
- Before: https://main--sling--aemsites.aem.live/whatson/entertainment
- After: https://365-blogcat--sling--aemsites.aem.live/whatson/entertainment

- Before: https://main--sling--aemsites.aem.live/whatson/sports
- After: https://365-blogcat--sling--aemsites.aem.live/whatson/sports
