### PR TITLE
no margin above embeds

### DIFF
--- a/aemedge/blocks/embed/embed.css
+++ b/aemedge/blocks/embed/embed.css
@@ -2,7 +2,7 @@
     width: 100%;
     text-align: center;
     max-width: 400px;
-    margin: 32px auto;
+    margin: 0 auto 32px;
 
     &.youtube, &.vimeo {
         min-height: 280px;


### PR DESCRIPTION

Fix #368 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/whatson/sports/baseball/watch-world-series-live
- After: https://368-spacing--sling--aemsites.aem.live/whatson/sports/baseball/watch-world-series-live
