### PR TITLE
Performance update to get mobile LHS to 100 for /whatson homepage

### DIFF
--- a/aemedge/blocks/category/category.js
+++ b/aemedge/blocks/category/category.js
@@ -9,6 +9,8 @@ import {
   pathToTag,
 } from '../../scripts/utils.js';
 
+const LATEST_50 = '50';
+
 // Create cardLarge images for 2 breakpoints
 export async function addCardImageLarge(row, style, eagerImage = true) {
   const cardImageDiv = createTag('div', { class: 'card-image' });
@@ -102,14 +104,14 @@ export default async function decorate(block) {
   }
 
   let blogsbypaths;
-  if (paths.length >= 1) blogsbypaths = await getBlogsByPaths(paths);
+  if (paths.length >= 1) blogsbypaths = await getBlogsByPaths(paths, LATEST_50);
   let blogs;
   let mergedBlogs;
   if (blogsbypaths && (blogsbypaths.length > 0 && blogsbypaths.length < 8)) {
     numberofblogs -= blogsbypaths.length;
     // Get blogs
     if (numberofblogs > 0) {
-      blogs = await getBlogs(categories.map((cat) => pathToTag(cat)), numberofblogs);
+      blogs = await getBlogs(categories.map((cat) => pathToTag(cat)), numberofblogs, LATEST_50);
       mergedBlogs = [...blogs, ...blogsbypaths];
     }
   } else {

--- a/aemedge/blocks/category/category.js
+++ b/aemedge/blocks/category/category.js
@@ -9,7 +9,7 @@ import {
   pathToTag,
 } from '../../scripts/utils.js';
 
-const LATEST_50 = '50';
+const QUERY_INDEX_LIMIT = '100';
 
 // Create cardLarge images for 2 breakpoints
 export async function addCardImageLarge(row, style, eagerImage = true) {
@@ -104,14 +104,18 @@ export default async function decorate(block) {
   }
 
   let blogsbypaths;
-  if (paths.length >= 1) blogsbypaths = await getBlogsByPaths(paths, LATEST_50);
+  if (paths.length >= 1) blogsbypaths = await getBlogsByPaths(paths, QUERY_INDEX_LIMIT);
   let blogs;
   let mergedBlogs;
   if (blogsbypaths && (blogsbypaths.length > 0 && blogsbypaths.length < 8)) {
     numberofblogs -= blogsbypaths.length;
     // Get blogs
     if (numberofblogs > 0) {
-      blogs = await getBlogs(categories.map((cat) => pathToTag(cat)), numberofblogs, LATEST_50);
+      blogs = await getBlogs(
+        categories.map((cat) => pathToTag(cat)),
+        numberofblogs,
+        QUERY_INDEX_LIMIT,
+      );
       mergedBlogs = [...blogs, ...blogsbypaths];
     }
   } else {

--- a/aemedge/blocks/category/category.js
+++ b/aemedge/blocks/category/category.js
@@ -9,7 +9,7 @@ import {
   pathToTag,
 } from '../../scripts/utils.js';
 
-const QUERY_INDEX_LIMIT = '100';
+const LIMIT_100 = '100';
 
 // Create cardLarge images for 2 breakpoints
 export async function addCardImageLarge(row, style, eagerImage = true) {
@@ -103,19 +103,20 @@ export default async function decorate(block) {
     lastSegmentOfURL = currentCategory;
   }
 
+  let limit = '';
+  // check if whatson homepage and add limit what we pull from query index for better performance
+  if (window.location.pathname === '/whatson' || window.location.pathname === '/whatson/') {
+    limit = LIMIT_100;
+  }
   let blogsbypaths;
-  if (paths.length >= 1) blogsbypaths = await getBlogsByPaths(paths, QUERY_INDEX_LIMIT);
+  if (paths.length >= 1) blogsbypaths = await getBlogsByPaths(paths, limit);
   let blogs;
   let mergedBlogs;
   if (blogsbypaths && (blogsbypaths.length > 0 && blogsbypaths.length < 8)) {
     numberofblogs -= blogsbypaths.length;
     // Get blogs
     if (numberofblogs > 0) {
-      blogs = await getBlogs(
-        categories.map((cat) => pathToTag(cat)),
-        numberofblogs,
-        QUERY_INDEX_LIMIT,
-      );
+      blogs = await getBlogs(categories.map((cat) => pathToTag(cat)), numberofblogs, limit);
       mergedBlogs = [...blogs, ...blogsbypaths];
     }
   } else {

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -227,11 +227,12 @@ function compareArrays(arr, arr2) {
  * Retrieves blogs matching specific tags
  * @param {Array} categories - An array of categories to filter by
  * @param {number} num - The number of blogs to retrieve
+ * @param {string} limit - The limit of blogs to retrieve from the query-index
  * @returns {Promise<Array>} - A promise resolving to the filtered blogs array
  */
-export async function getBlogs(categories, num) {
+export async function getBlogs(categories, num, limit = '') {
   if (!window.allBlogs) {
-    window.allBlogs = await fetchData('/whatson/query-index.json?limit=50');
+    window.allBlogs = await fetchData(`/whatson/query-index.json${limit ? `?limit=${limit}` : ''}`);
   }
   const blogArticles = window.allBlogs.filter(
     (e) => (e.template === 'blog-article' && e.image !== '' && !e.image.startsWith('//aemedge/default-meta-image.png')),
@@ -254,9 +255,9 @@ export async function getBlogs(categories, num) {
   return blogArticles;
 }
 
-export async function getBlogsByPaths(paths) {
+export async function getBlogsByPaths(paths, limit = '') {
   if (!window.allBlogs) {
-    window.allBlogs = await fetchData('/whatson/query-index.json');
+    window.allBlogs = await fetchData(`/whatson/query-index.json${limit ? `?limit=${limit}` : ''}`);
   }
   const blogArticles = window.allBlogs.filter(
     (e) => (e.template !== 'blog-category' && e.image !== '' && !e.image.startsWith('//aemedge/default-meta-image.png')),

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -231,7 +231,7 @@ function compareArrays(arr, arr2) {
  */
 export async function getBlogs(categories, num) {
   if (!window.allBlogs) {
-    window.allBlogs = await fetchData('/whatson/query-index.json');
+    window.allBlogs = await fetchData('/whatson/query-index.json?limit=50');
   }
   const blogArticles = window.allBlogs.filter(
     (e) => (e.template === 'blog-article' && e.image !== '' && !e.image.startsWith('//aemedge/default-meta-image.png')),


### PR DESCRIPTION
Limiting the number of entries returned by query-index for the category home page only to 100 essentially reducing the size of the json so that we can get to LCP faster.

Rationale: the homepage has stuff across all categories that are really the latest 7 or in the latest 20 if manually curated. so I've kept the limit to 100 because the top 58 entries while sorted on date do not have a date in the QI and are other pages. so that gives us about 40 ish latest blogs. Another option is to use a different sheet in query-index that only has blog articles and not author pages etc.. for the category block to use. then we can limit the response even further to 20 or 50 for the homepage and the full list for other category pages (assuming some categories aren't updated that frequently)

Fix #377 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/whatson
- After: https://perf--sling--aemsites.aem.live/whatson
