### PR TITLE
omit 2 categories of articles auto-populating on homepg

### DIFF
--- a/aemedge/scripts/delayed.js
+++ b/aemedge/scripts/delayed.js
@@ -21,10 +21,10 @@ sampleRUM('cwv');
 // adding launch.js to all but prod so as not to interfere with prod statistics
 // if they need it, uncomment it after go live.
 
-if (window.location.host.endsWith('.page') || window.location.host.startsWith('localhost')) {
+if (window.location.host.startsWith('localhost')) {
   loadScript('https://assets.adobedtm.com/f4211b096882/26f71ad376c4/launch-b69ac51c7dcd-development.min.js');
-} else if (window.location.host.startsWith('www.sling.com')) {
+} else if (window.location.host.startsWith('www.sling.com') || window.location.host.endsWith('.live')) {
   // loadScript('https://assets.adobedtm.com/f4211b096882/26f71ad376c4/launch-c846c0e0cbc6.min.js');
-} else if (window.location.host.startsWith('www.b.sling.com')) {
+} else if (window.location.host.endsWith('.page')) {
   loadScript('https://assets.adobedtm.com/f4211b096882/26f71ad376c4/launch-6367a8aeb307-staging.min.js');
 }

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -237,11 +237,15 @@ export async function getBlogs(categories, num, limit = '') {
   const blogArticles = window.allBlogs.filter(
     (e) => (e.template === 'blog-article' && e.image !== '' && !e.image.startsWith('//aemedge/default-meta-image.png')),
   );
-
-  if (categories && categories.length > 0) {
+  // If page is the home page, omit international and announcements tagged articles
+  const homeBlogPage = window.location.pathname === '/whatson';
+  if (homeBlogPage || (categories && categories.length > 0)) {
     const filteredList = blogArticles.filter((e) => {
       const rawTags = JSON.parse(e.tags);
       const tags = rawTags.map((tag) => tag.trim().toLowerCase());
+      if (homeBlogPage) {
+        return !tags.includes('international') && !tags.includes('announcements');
+      }
       return compareArrays(categories, tags);
     });
     if (num) {


### PR DESCRIPTION
The blog homepage will omit 'international' and 'announcements' tagged blogs from auto-populating. The manual links, if authored, will render as expected, regardless of how those might be tagged.

Also, I edited when we include the launch script URLs since we are not using b.sling.com anymore.

Fix #369-whatsoncats

Test URLs:
Note that this article list will remain unchanged, due to the 6 manual links authored.
- Before: https://main--sling--aemsites.aem.live/whatson
- After: https://369-whatsoncats--sling--aemsites.aem.live/whatson

This should be unchanged, to show that only the /whatson page is filtering out the international tag:
- Before: https://main--sling--aemsites.aem.live/whatson/international
- After: https://369-whatsoncats--sling--aemsites.aem.live/whatson/international

This should also be unchanged, to show that only the /whatson page is filtering out the announcements tag:
- Before: https://main--sling--aemsites.aem.live/whatson/announcements
- After: https://369-whatsoncats--sling--aemsites.aem.live/whatson/announcements

For testing: 
- In my local, I had set the window.location.pathname to various test pages such as /whatsonnolink to check different auto + manual linked articles to confirm nothing was broken. Here's a screenshot of my test page when on my local:

![image](https://github.com/user-attachments/assets/a1378f6f-f3c5-43b2-a79f-dfe0fc15e149)

- but you can also test the /whatson page by temporarily removing the manual links and previewing (but not publishing) the page to see that 2 int'l pages will be listed. Then put the links back + re-preview.