### PR TITLE
reverting change to not to show announcements pages on homepage

### DIFF
--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -244,7 +244,7 @@ export async function getBlogs(categories, num, limit = '') {
       const rawTags = JSON.parse(e.tags);
       const tags = rawTags.map((tag) => tag.trim().toLowerCase());
       if (homeBlogPage) {
-        return !tags.includes('international') && !tags.includes('announcements');
+        return !tags.includes('international');
       }
       return compareArrays(categories, tags);
     });


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #394 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/whatson
- After: https://394-announcements--sling--aemsites.aem.live/whatson
