### PR TITLE
dynamic media images + /svgs

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -22,6 +22,7 @@ import {
   createTag,
   loadGameFinders,
   loadPackageCards,
+  linkTextIncludesHref,
 } from './utils.js';
 
 const LCP_BLOCKS = ['category']; // add your LCP blocks to the list
@@ -416,6 +417,27 @@ function buildSpacer(main) {
   });
 }
 
+export function decorateExtImage() {
+  // specific to dynamic media but we can add a local path too
+  // but for non-svg images, we will need to tell DM what size image we need
+  const extImageUrl = /dish\.scene7\.com/;
+  document.querySelectorAll('a[href]').forEach((a) => {
+    if (extImageUrl.test(a.href) && linkTextIncludesHref(a)) {
+      const extImageSrc = a.href;
+      const picture = document.createElement('picture');
+      const img = document.createElement('img');
+      img.classList.add('external');
+      // this alt is a cop out, but it's better than nothing
+      img.alt = 'Sling TV image';
+      // making assumption it is not LCP but we can add a check
+      img.loading = 'lazy';
+      img.src = extImageSrc;
+      picture.append(img);
+      a.replaceWith(picture);
+    }
+  });
+}
+
 /**
    * Builds all synthetic blocks in a container element.
    * @param {Element} main The container element
@@ -457,6 +479,7 @@ export function decorateMain(main) {
   decorateBlocks(main);
   decorateStyledSections(main);
   buildSpacer(main);
+  decorateExtImage(main);
   decorateLinkedImages();
 }
 

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -418,18 +418,18 @@ function buildSpacer(main) {
 }
 
 export function decorateExtImage() {
-  // specific to dynamic media but we can add a local path too
-  // but for non-svg images, we will need to tell DM what size image we need
-  const extImageUrl = /dish\.scene7\.com/;
+  // dynamic media link or images in /svg folder
+  // not for bitmap images because we're not doing renditions here
+  const extImageUrl = /dish\.scene7\.com|\/aemedge\/svgs\//;
   document.querySelectorAll('a[href]').forEach((a) => {
     if (extImageUrl.test(a.href) && linkTextIncludesHref(a)) {
       const extImageSrc = a.href;
       const picture = document.createElement('picture');
       const img = document.createElement('img');
-      img.classList.add('external');
+      img.classList.add('svg');
       // this alt is a cop out, but it's better than nothing
       img.alt = 'Sling TV image';
-      // making assumption it is not LCP but we can add a check
+      // making assumption it is not LCP
       img.loading = 'lazy';
       img.src = extImageSrc;
       picture.append(img);

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -380,7 +380,7 @@ main img {
   width: 24px;
 }
 
-.icon img {
+.icon img, img.svg {
   height: 100%;
   width: 100%;
 }


### PR DESCRIPTION
For SVG use, this is perfect because no media query srcset is needed, since SVGs are all math.
SVG files that we want to render at normal size should be put in the /aemedge/svgs folder now (not /icons).

Dynamic media images can also be linked as a bonus but don't use for bitmaps as no renditions are being returned currently.

Fix #148 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/international
- After: https://148-dynamicmedia--sling--aemsites.aem.live/international

- Before: https://main--sling--aemsites.aem.live/aemedge/fragments/rewards/freestream-rewards-banner/freestream-rewards-banner
- After: https://148-dynamicmedia--sling--aemsites.aem.live/aemedge/fragments/rewards/freestream-rewards-banner/freestream-rewards-banner

