### PR TITLE
small margin fix for when there is not a foreground image present

### DIFF
--- a/aemedge/blocks/marquee/marquee.css
+++ b/aemedge/blocks/marquee/marquee.css
@@ -147,7 +147,7 @@ h2 {
     }
   }
 
-  .foreground-container { 
+  .foreground-container {
     padding-top: 1.5rem;
   }
 }
@@ -169,6 +169,7 @@ h2 {
       width: 50%;
       max-width: 600px;
       padding-right: 1.5rem;
+      margin: unset;
 
       .buttons-container {
           display: block;
@@ -193,7 +194,7 @@ h2 {
     margin: 0;
 }
 
-.buttons-container .button-container { 
+.buttons-container .button-container {
   text-align: center;
 }
 


### PR DESCRIPTION
Adjusting the margin fixes the position of the main headline text in the marquee when there isn't a foreground image.
Adding a blank PNG as the foreground in the /rewards page 'fixes' the height of the marquee in mobile -- which is what they currently do on their live site.

Fix #339 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/programming
- After: https://339-marqueefix--sling--aemsites.aem.live/programming
- Before: https://main--sling--aemsites.aem.live/rewards
- After: https://339-marqueefix--sling--aemsites.aem.live/rewards
