### PR TITLE
fixed game finder spacing

### DIFF
--- a/aemedge/blocks/columns/columns.css
+++ b/aemedge/blocks/columns/columns.css
@@ -409,8 +409,8 @@
     }
 
     .columns.icons span.icon img {
-      height: 36px;
-      width: 96px;
+      height: 100%;
+      width: 100%;
     }
 
     .columns.landing p { 

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -501,11 +501,14 @@ main .icon-still-have-questions img {
   padding: 8%;
 }
 
+.section.game-finder-container{
+  padding: 0;
+}
+
 .section.game-finder-container .game-finder-wrapper
 {
-    width: 80%;
-    margin: 0 auto;
-    padding-top: 10px;
+    width: 83.3333%;
+    margin-left: 8.33%;
     max-width: 1440px;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #447

Test URLs:
- Before: https://main--sling--aemsites.aem.page/programming/sports/pro-football
- After: https://447-gamefinder--sling--aemsites.aem.page/programming/sports/pro-football
