### PR TITLE
fixed the positioning of logo and menu icon in mobile header

### DIFF
--- a/aemedge/blocks/header/header.css
+++ b/aemedge/blocks/header/header.css
@@ -40,7 +40,6 @@ header nav[aria-expanded="false"] {
 }
 
 header nav .nav-brand {
-  position: fixed;
   top: 0;
 }
 
@@ -97,7 +96,6 @@ header nav .nav-hamburger {
   display: flex;
   align-items: center;
   justify-self: flex-end;
-  position: fixed;
   top: 16px;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #454 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/programming/sports
- After: https://454-header--sling--aemsites.aem.live/programming/sports

Note - Please test this in Safari if you are on Mac / IOS device  to reproduce this issue