### PR TITLE
1st 2 divs will be in 2 columns

### DIFF
--- a/aemedge/blocks/modal/modal.css
+++ b/aemedge/blocks/modal/modal.css
@@ -9,6 +9,11 @@ body.modal-open {
     border: 1px solid var(--dark-color);
     border-radius: var(--dialog-border-radius);
     width: 100vw;
+
+      p, li {
+        font-size: 1em;
+        line-height: 1.5;
+      }
   }
 
   .modal dialog .modal-content {

--- a/aemedge/blocks/package-cards/package-cards.css
+++ b/aemedge/blocks/package-cards/package-cards.css
@@ -1,7 +1,32 @@
 /* stylelint-disable selector-class-pattern */
+.package-cards-container.section {
+    background-color: var(--clr-white);
+    border-radius: 4px;
+    box-shadow: 0 5px 15px 0 rgb(0 0 0 / 14%);
+    padding: 12px 40px 40px;
+    margin: 50px 8%;
 
-.package-cards.block > div:not([id]) p {
-    display: none;
+    p, li {
+        font-size: 1.125em;
+        line-height: 1.35em;
+    }
+
+    .buttons-container {
+        margin: 24px auto 0;
+    }
+
+    .package-cards-container {
+        box-shadow: none;
+        padding: unset;
+        margin: unset;
+        border-radius: 0;
+    }
+}
+
+.package-cards.block {
+    > div:not([id]) p {
+        display: none;
+    }
 }
 
 
@@ -9,7 +34,6 @@
 .package-cards.block #package-cards-app button.next-arrow-blue,
 .package-cards.block #package-cards-app button.back-arrow-orange,
 .package-cards.block #package-cards-app button.next-arrow-orange,
-.package-cards.block #package-cards-app button.sc-kgAjT,
 .package-cards.block #package-cards-app button[aria-label="close"]
  {
    padding: unset;
@@ -21,11 +45,6 @@
 .package-cards.block #package-cards-app a:any-link {
     color:initial;
     border-radius: 1600px;
-}
-
-.package-cards.block #package-cards-app div.VhpVA { 
-    inset: 50px 0;
-    height: 100vh;
 }
 
 .package-cards.block #package-cards-app a.blue-homepage-base-card-cart-link {
@@ -48,22 +67,42 @@
     z-index: 0;
 }
 
-.package-cards.block #package-cards-app div.eMQgdL > *{
-    height: 479px;
-}
-
 .package-cards.block #package-cards-app img {
     width: auto;
     height: auto;
 }
 
-.package-cards.block #package-cards-app .bnPtBS {
-    z-index:1;
+@media (width >= 768px) {
+    .package-cards-container.section {
+        padding: 48px;
+
+        .package-cards.block {
+            margin-bottom: 48px;
+        }
+    }
+
+    .PackageExtraCards {
+        display: flex;
+        justify-content: center;
+    }
 }
 
-@media (width >= 768px) {
-.package-cards.block #package-cards-app .fIvgai {
-    right: 12px;
-    top: 28px;
+@media (width >= 1024px) {
+    .package-cards-container.section.columns-2 {
+        flex-direction: column;
+    }
 }
+
+@media (width >= 1200px) {
+    .package-cards-container.section.columns-2 {
+        flex-direction: row;
+
+        .column-1 {
+            width: 60%;
+        }
+
+        .column-2 {
+            width: 40%;
+        }
+    }
 }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -224,6 +224,49 @@ function createOptimizedBackgroundImage(section, breakpoints = [
   updateBackground();
 }
 
+function makeTwoColumns(main) {
+  const sections = main.querySelectorAll('.section.columns-2');
+  sections.forEach((section) => {
+    const columnTarget = section.querySelector('div:nth-child(odd)');
+    const columnOne = document.createElement('div');
+    columnOne.classList.add('column-1');
+    columnOne.append(...columnTarget.children);
+    const columnTwo = document.createElement('div');
+    columnTwo.classList.add('column-2');
+    const columnTwoItems = section.querySelector('div:nth-child(even)');
+    columnTwo.append(columnTwoItems);
+    columnTarget.append(columnOne, columnTwo);
+  });
+}
+
+/**
+ * consolidate the offer boxes into one wrapper div
+ *
+ * @param main
+ */
+/*
+function consolidateSectionColumns(main) {
+  const ob = main.querySelectorAll('.offer-box-wrapper');
+  let firstOB;
+  if (ob && ob.length > 1) {
+    ob.forEach((box, index) => {
+      if (index === 0) {
+        firstOB = box;
+      } else {
+        firstOB.append(...box.children);
+        box.remove();
+      }
+    });
+    if (main.querySelector('.section.offer-box-container.two-columns')) {
+      makeTwoColumns(main);
+    }
+  }
+}
+
+ */
+
+
+
 /**
  * Finds all sections in the main element of the document
  * that require adding a background image
@@ -507,6 +550,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  makeTwoColumns(main);
   decorateStyledSections(main);
   buildSpacer(main);
   decorateExtImage(main);

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -226,22 +226,36 @@ function createOptimizedBackgroundImage(section, breakpoints = [
 
 /**
  * consolidate the first two divs in a section into two columns
- *
+ * Special case for when there is 1 fragment-wrapper
  * @param main
  */
 
 function makeTwoColumns(main) {
   const sections = main.querySelectorAll('.section.columns-2');
+  let columnTarget;
+  let columnTwoItems;
   sections.forEach((section) => {
-    const columnTarget = section.querySelector('div:nth-child(odd)');
+    const fragmentSections = section.querySelector('.fragment-wrapper');
     const columnOne = document.createElement('div');
     columnOne.classList.add('column-1');
-    columnOne.append(...columnTarget.children);
     const columnTwo = document.createElement('div');
     columnTwo.classList.add('column-2');
-    const columnTwoItems = section.querySelector('div:nth-child(even)');
-    columnTwo.append(columnTwoItems);
-    columnTarget.append(columnOne, columnTwo);
+    if (!fragmentSections) {
+      // 1 block div plus 1 default content div only
+      columnTarget = section.querySelector('div:nth-child(odd)');
+      columnOne.append(...columnTarget.children);
+      columnTwoItems = section.querySelector('div:nth-child(even)');
+      columnTwo.append(columnTwoItems);
+      section.innerHTML = ''; // any extra divs are removed
+      section.append(columnOne, columnTwo);
+    } else {
+      // 1 fragment-wrapper div plus 1 default content div only
+      columnTarget = section.querySelector('.fragment-wrapper');
+      columnOne.append(...columnTarget.children);
+      columnTwoItems = section.querySelector('div');
+      columnTwo.append(columnTwoItems);
+      section.append(columnOne, columnTwo);
+    }
   });
 }
 

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -224,6 +224,12 @@ function createOptimizedBackgroundImage(section, breakpoints = [
   updateBackground();
 }
 
+/**
+ * consolidate the first two divs in a section into two columns
+ *
+ * @param main
+ */
+
 function makeTwoColumns(main) {
   const sections = main.querySelectorAll('.section.columns-2');
   sections.forEach((section) => {
@@ -238,34 +244,6 @@ function makeTwoColumns(main) {
     columnTarget.append(columnOne, columnTwo);
   });
 }
-
-/**
- * consolidate the offer boxes into one wrapper div
- *
- * @param main
- */
-/*
-function consolidateSectionColumns(main) {
-  const ob = main.querySelectorAll('.offer-box-wrapper');
-  let firstOB;
-  if (ob && ob.length > 1) {
-    ob.forEach((box, index) => {
-      if (index === 0) {
-        firstOB = box;
-      } else {
-        firstOB.append(...box.children);
-        box.remove();
-      }
-    });
-    if (main.querySelector('.section.offer-box-container.two-columns')) {
-      makeTwoColumns(main);
-    }
-  }
-}
-
- */
-
-
 
 /**
  * Finds all sections in the main element of the document

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -492,7 +492,6 @@ main .icon-still-have-questions img {
   flex-direction: column-reverse;
 }
 
-
 /* Section with Dark or Centered content */
 .section.dark {
   background-color: var(--dark-background-color);
@@ -797,6 +796,18 @@ a.black {
       align-items: center;
     }
   }
+
+    .section.columns-2 {
+        margin-left: 8%;
+        margin-right: 8%;
+        width: 83%;
+
+        > div {
+            display: flex;
+            flex-direction: row;
+            gap: 8%;
+        }
+    }
 
   section > .default-content-wrapper > p.fragment-wrapper {
     .section.banner {

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -601,20 +601,6 @@ margin-bottom:10px;
 }
 
 .section.package-cards-container.offer-details {
-    margin: 64px 0;
-
-    .buttons-container {
-        align-items: normal;
-
-       .button-container .buttons-container {
-            align-items: center;
-
-           .button-container {
-               align-items: center;
-           }
-        }
-    }
-
 .columns.block > div {
     border-radius: 4px;
     box-shadow: 0 5px 15px 0 rgb(0 0 0 / 14%);

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -149,6 +149,10 @@ blockquote {
   margin: 0;
 }
 
+.button-container sub, sup {
+  font-size: 0.875rem;
+}
+
 .buttons-container .button-container{
   margin: 0;
 }
@@ -423,7 +427,6 @@ main .section {
   margin: 0;
 }
 
-
 /* FAQ Section */
 .section.tabs-container.accordion-container .default-content-wrapper {
   text-align: center;
@@ -443,8 +446,6 @@ main .section {
   margin: 0;
   padding: 0;
   background-position: center;
-
-
 
   .buttons-container {
     text-align: center;
@@ -482,7 +483,6 @@ main .icon-still-have-questions img {
   padding:0;
   -moz-osx-font-smoothing: grayscale;
 }
-
 
 .section.wide-columns .columns.block  div {
   margin-bottom: 50px;
@@ -522,7 +522,6 @@ main .icon-still-have-questions img {
   text-align:center;
   margin-bottom: 10px;
 }
-
 
 .section.game-finder-container > .default-content-wrapper > h2 {
   font-size: 40px;
@@ -710,24 +709,6 @@ a.black {
         padding: 64px 32px;
     }
 
-    /* package cards desktop styles
-.section.package-cards-container.offer-details {
-    padding: 0 18px;
-
-    .columns.block > div {
-        .section.package-cards-container {
-            margin: unset;
-            padding: 0;
-        }
-    }
-}
-
-     */
-    .section.package-cards-container .offer-details a.button.text {
-        color: unset;
-    }
-
-
     .section.wide-columns .columns.block div {
         margin-bottom: 20px;
     }
@@ -763,13 +744,6 @@ a.black {
         margin: 0 auto;
     }
 
-
-    /* stylelint-disable-next-line selector-class-pattern */
-    .section.package-cards-container #package-cards-app .hlmNfh {
-        flex-direction: column;
-        align-items: unset;
-    }
-
     .section.channel-shopper-container {
         text-align: left;
 
@@ -798,12 +772,11 @@ a.black {
   }
 
     .section.columns-2 {
-        margin-left: 8%;
-        margin-right: 8%;
-        width: 83%;
+        margin-left: 11%;
+        margin-right: 11%;
+        display: flex;
 
         > div {
-            display: flex;
             flex-direction: row;
             gap: 8%;
         }
@@ -829,20 +802,8 @@ main h2#still-have-questions {
 
 main .icon-still-have-questions img {
   width: 64px!important;
-
 }
-
 }
-
-@media (width >=1540px) {
-
-    /* stylelint-disable-next-line selector-class-pattern */
-.section.package-cards-container #package-cards-app .hlmNfh
-{
-  flex-direction: row;
-    align-items: center;
-}
- }
 
 /* section metadata */
 main .section.light,


### PR DESCRIPTION
When section (columns-2) is used, the first 2 child divs will turn into 2 columns. (Any remaining divs will just load 100% after that.)
This works whether the package cards block is a fragment in the 1st column or if it is a directly-placed block.

Fix #474 , #446

Test URLs: 
On thess pages, the Try Sling buttons are using the live fragments (which are not the right style).

- Before: https://main--sling--aemsites.aem.page/programming/entertainment
- After: https://474-col-2section--sling--aemsites.aem.page/programming/entertainment

- Before: https://main--sling--aemsites.aem.page/programming/sports/pro-football
- After: https://474-col-2section--sling--aemsites.aem.page/programming/sports/pro-football

On this page, I've replaced the fragments with individual buttons using better style. In a future ticket, the existing button fragments should be updated to look like these.
- Before: https://main--sling--aemsites.aem.page/programming/sports
- After: https://474-col-2section--sling--aemsites.aem.page/programming/sports




