### PR TITLE
add blue to subscript default

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -147,9 +147,11 @@ function autolinkModals(element) {
 }
 
 export function buildMultipleButtons(main) {
-  const buttons = main.querySelectorAll('p.button-container');
+  const buttons = main.querySelectorAll('.button-container');
   buttons.forEach((button) => {
-    if (button.nextElementSibling && button.nextElementSibling.classList.contains('button-container')) {
+    if (button.nextElementSibling
+        && (button.nextElementSibling.classList.contains('button-container')
+            || (button.nextElementSibling.firstElementChild && button.nextElementSibling.firstElementChild.classList.contains('button-container')))) {
       const siblingButton = button.nextElementSibling;
       if (siblingButton && !button.parentElement.classList.contains('buttons-container')) {
         const buttonContainer = createTag('div', { class: 'buttons-container' });
@@ -328,7 +330,7 @@ export function decorateButtons(element) {
         const isSubscript = Tagname === 'sub';
         const isSuperscript = Tagname === 'sup';
         if (isSubscript) {
-          a.classList.add('black');
+          a.classList.add('blue');
           a.parentElement.classList.add('button-container');
         } else if (isSuperscript) {
           a.classList.add('white');

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -149,13 +149,9 @@ blockquote {
   margin: 0;
 }
 
-.button-container sub, sup {
-  font-size: 0.875rem;
-}
 
-.buttons-container .button-container{
-  margin: 0;
-}
+
+
 
 code,
 pre {
@@ -300,12 +296,17 @@ button:disabled:hover {
     a.button {
         margin: 8px 0 0;
     }
+}
 
-    sub, sup {
+.button-container {
+    margin: 0;
+
+    sub, sup, em sup, em sub {
         display: block;
         text-align: center;
         font-style: italic;
         margin-top: 6px;
+        font-size: 0.875rem;
     }
 }
 
@@ -651,8 +652,12 @@ a.white {
   color: white;
 }
 
-a.black {
+a.black, em.button-container > a.blue {
   color: black;
+}
+
+a.blue {
+    color: var(--link-color);
 }
 
 @media (width >=768px) {


### PR DESCRIPTION
This PR makes subtext formatted as subscript be the default link blue color, and making the subscript italic will make the link black.

Fix #478 

Test URLs:
- Before: https://main--sling--aemsites.aem.live
- After: https://478-subtext--sling--aemsites.aem.live
/drafts/chelms/sports
