### PR TITLE
button without section fix for blog

### DIFF
--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -334,7 +334,7 @@ button.text:hover {
   box-shadow: none;
 }
 
-body.blog-article .offer-details .buttons-container {
+body.blog-article .buttons-container {
   display: flex;
   flex-direction: column;
   place-content: center;

--- a/aemedge/templates/blog-article/blog-article.css
+++ b/aemedge/templates/blog-article/blog-article.css
@@ -155,6 +155,10 @@ main .hero-container + .section {
     padding: 0 4px
 }
 
+a.black, em.button-container > a.blue {
+    color: var(--link-color);
+}
+
 .blog-article p a:hover,
 .blog-article .auth-name a:hover {
     color: var(--link-hover-color);


### PR DESCRIPTION
To test this, I created a new button fragment (temporarily) but after this merge, I will edit the real button fragments and remove the section.

Fix #482 

Test URLs:
I only replaced the 2nd button - you will see it has centered and it has black text
- Before: https://main--sling--aemsites.aem.live/programming/sports/pro-football
- After: https://482-blogbutton--sling--aemsites.aem.live/programming/sports/pro-football

Same button fragment is blue in Blog as before
- Before: https://main--sling--aemsites.aem.page/whatson/sports/college-football/000test2020-college-football-playoff-preview
- After: https://482-blogbutton--sling--aemsites.aem.page/whatson/sports/college-football/000test2020-college-football-playoff-preview