### PR TITLE
fix button group, clean banner styles

### DIFF
--- a/aemedge/blocks/channel-shopper/channel-shopper.css
+++ b/aemedge/blocks/channel-shopper/channel-shopper.css
@@ -1,4 +1,7 @@
 /* stylelint-disable selector-class-pattern */
+.channel-shopper-container {
+    text-align: center;
+}
 
 .channel-shopper-container p {
     margin: 0;
@@ -27,9 +30,6 @@
     min-width: unset;
     margin-top: unset;
     margin-bottom: unset;
-}
-
-.channel-shopper.block #channel-shopper-app button.kBfRPX {
     background: var(--primary-button-color);
     border-radius: 1600px;
     border: transparent;

--- a/aemedge/blocks/columns/columns.css
+++ b/aemedge/blocks/columns/columns.css
@@ -108,8 +108,8 @@
       -webkit-box-pack: center;
       justify-content: center;
       -webkit-box-align: center;
-      padding: 4rem 1.25rem 2.5rem;
-      width: 100%;
+      padding: 2.5rem 0;
+      margin: 0 8%;
     }
   }
 
@@ -441,7 +441,7 @@
 
           > div:first-child {
             flex: 2 1 0;
-            padding: 3.6rem 3.25rem;
+            padding: 3.6rem 0;
           }
 
           .buttons-container {
@@ -467,7 +467,7 @@
     .channel-shopper-container .columns {
       > div:first-of-type { /* stylelint-disable-line */
         > div:first-child {
-          padding: 0;
+          padding: 2rem 0 0;
         }
 
         .columns-img-col picture > img {
@@ -488,12 +488,3 @@
     }
   }
 
-  @media (width >=1440px) {
-    .banner .columns {
-      > div:first-of-type {
-        > div:first-child {
-          padding: 1rem 6.25rem;
-        }
-      }
-    }
-  }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -308,9 +308,8 @@ export function decorateButtons(element) {
   element.querySelectorAll('a').forEach((a) => {
     // Set the title attribute if not already set
     a.title = a.title || a.textContent;
-
-    // Proceed only if href is different from textContent
-    if (a.href !== a.textContent) {
+    // Proceed only if href is different from textContent and is not a fragment link
+    if (a.href !== a.textContent && !a.href.includes('/fragments/')) {
       const hasIcon = a.querySelector('.icon');
       const up = a.parentElement;
       const twoup = up.parentElement;

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -419,8 +419,8 @@ main img {
 }
 
 /* sections */
-main .section {
-  padding: 0 16px;
+main > .section {
+  padding: 0 8%;
   margin: 64px 0;
 }
 
@@ -586,15 +586,12 @@ margin-bottom:10px;
   width: 180px;
 }
 
-.section.channel-shopper-container {
+.main > .columns-2.banner {
     padding: 0;
   max-width: 100%;
   margin:0 auto;
   text-align: center;
 
-    .button-container:first-of-type > .channel-shopper-container {
-        padding:32px 24px;
-    }
 }
 
 .section.tabs-container .tabs-wrapper {
@@ -663,6 +660,10 @@ a.blue {
 @media (width >=768px) {
     main .section {
         padding: 0 48px;
+    }
+
+    main .section.channel-shopper-container {
+        padding: 0;
     }
 
     .international main .icons .icon img {
@@ -740,12 +741,7 @@ a.blue {
 
         .columns > div {
             flex-direction: row;
-            width: 86.5%;
             margin: 0 auto;
-
-        .columns-img-col {
-            margin-left: 20%;
-        }
         }
     }
 }


### PR DESCRIPTION
fixed nested button-containers when button is inside a fragment;
settled on a standard of 8% left and right margins for banners so they match package cards.

Fix #484 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/programming/sports
- After: https://484-sportspages--sling--aemsites.aem.live/programming/sports
