### PR TITLE
507 banner-image block

### DIFF
--- a/aemedge/blocks/banner-image/banner-image.css
+++ b/aemedge/blocks/banner-image/banner-image.css
@@ -60,42 +60,41 @@
             line-height: 1.1;
         }
 
+        .headline p {
+            font-size: var(--heading-font-size-l);
+            line-height: 30px;
+        }
+
         .sub-headline p {
             line-height: 1.25;
         }
-    }
 
-    .headline p {
-        font-size: var(--heading-font-size-l);
-        line-height: 30px;
-    }
+        .sub-headline picture img {
+            width: auto;
+            height: auto;
+        }
 
-    .sub-headline picture img {
-        width: auto;
-        height: auto;
-    }
+        > .buttons-container {
+            display: flex;
+            flex-direction: column;
+            -webkit-box-align: center;
+            align-items: center;
+            width: 100%;
+            margin:0 auto;
 
-    .text-cta-container .buttons-container p {
-        margin:0;
+            a.button.primary {
+                min-width: 180px;
+            }
+        }
+
+        .buttons-container p {
+            margin:0;
+        }
     }
 
     .foreground-container {
         margin: 1rem auto 0;
         text-align: center;
-    }
-
-    .text-cta-container > .buttons-container
-    {
-        display: flex;
-        flex-direction: column;
-        -webkit-box-align: center;
-        align-items: center;
-        width: 100%;
-        margin:0 auto;
-
-        a.button.primary {
-            min-width: 180px;
-        }
     }
 
     .offer-details a.button.text {
@@ -109,43 +108,6 @@
     }
 }
 
-
-.banner-image .background {
-    position:absolute;
-    z-index: 0;
-    inset: 0;
-    height: 100%;
-
-    picture {
-        display: unset;
-    }
-
-    picture img{
-        position: relative;
-        z-index: 0;
-        object-fit: cover;
-        width: 100%;
-        box-sizing: border-box;
-        inset: 0;
-        height: 100%;
-    }
-}
-
-.rewards .section.marquee-container .marquee .marquee-content .text-cta-container .sub-headline h2 a{
-    color: #00b9ff;
-}
-
-.rewards .section.marquee-container .marquee-wrapper .marquee.block .marquee-content .text-cta-container .headline p picture img{
-    width: 30%;
-}
-
-.rewards .section.marquee-container .marquee-wrapper .marquee.block .marquee-content .text-cta-container .buttons-container p a{
-    margin-top: 10px;
-    margin-left: 0;
-}
-
-
-
 @media (width >= 768px) {
     .banner-image.block {
         &.min-height {
@@ -158,7 +120,6 @@
     }
 
     .banner-content {
-
         .text-cta-container {
             > .buttons-container {
                 width: fit-content;
@@ -174,6 +135,11 @@
 @media (width >= 1024px) {
     .banner-image.block {
         height: 100%;
+
+        .buttons-container {
+            display: block;
+            margin: 0;
+        }
 
         &.small .buttons-container {
             position: absolute;
@@ -199,11 +165,6 @@
         .text-cta-container {
             padding-right: 1.5rem;
             margin: unset;
-
-            .buttons-container {
-                display: block;
-                margin: 0;
-            }
         }
 
         .foreground-container {
@@ -222,6 +183,6 @@
 
 @media (width >= 1440px) {
     .banner-content .text-cta-container {
-        margin:unset;
+        margin: unset;
     }
 }

--- a/aemedge/blocks/banner-image/banner-image.css
+++ b/aemedge/blocks/banner-image/banner-image.css
@@ -1,0 +1,227 @@
+.banner-image.block {
+    color: var(--clr-white);
+    position: relative;
+    border: none;
+    overflow: hidden;
+    background-repeat: no-repeat !important;
+    height: fit-content;
+
+    &.min-height {
+        min-height: 452px;
+    }
+
+    &.small.min-height {
+        min-height: 342px;
+    }
+}
+
+.banner-content {
+    color: var(--clr-white);
+    border: none;
+    padding: 48px 8%;
+    display: flex;
+    -webkit-box-pack: justify;
+    flex-flow: column;
+    inset: 0;
+    box-sizing: border-box;
+    width: 100%;
+    -webkit-box-align: start;
+    align-items: start;
+    text-align: left;
+    position: relative;
+    height: 100%;
+
+    .text-cta-container {
+        margin-top: 1rem;
+        width: 100%;
+
+        .headline > * {
+            margin-top: 0;
+            padding-top: 0;
+        }
+
+        .headline h2 {
+            font-size: 2rem;
+            margin-bottom: 20px;
+        }
+
+        .sub-headline > *:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+        }
+
+        .sub-headline h2 {
+            font-size: 24px;
+            line-height: 2.125rem;
+        }
+
+        .sub-headline h3 {
+            font-size: 20px;
+            line-height: 1.1;
+        }
+
+        .sub-headline p {
+            line-height: 1.25;
+        }
+    }
+
+    .headline p {
+        font-size: var(--heading-font-size-l);
+        line-height: 30px;
+    }
+
+    .sub-headline picture img {
+        width: auto;
+        height: auto;
+    }
+
+    .text-cta-container .buttons-container p {
+        margin:0;
+    }
+
+    .foreground-container {
+        margin: 1rem auto 0;
+        text-align: center;
+    }
+
+    .text-cta-container > .buttons-container
+    {
+        display: flex;
+        flex-direction: column;
+        -webkit-box-align: center;
+        align-items: center;
+        width: 100%;
+        margin:0 auto;
+
+        a.button.primary {
+            min-width: 180px;
+        }
+    }
+
+    .offer-details a.button.text {
+        max-width: 200px;
+        margin-top:10px;
+
+        .link-button-text {
+            color:#fff;
+            font-weight: 500;
+        }
+    }
+}
+
+
+.banner-image .background {
+    position:absolute;
+    z-index: 0;
+    inset: 0;
+    height: 100%;
+
+    picture {
+        display: unset;
+    }
+
+    picture img{
+        position: relative;
+        z-index: 0;
+        object-fit: cover;
+        width: 100%;
+        box-sizing: border-box;
+        inset: 0;
+        height: 100%;
+    }
+}
+
+.rewards .section.marquee-container .marquee .marquee-content .text-cta-container .sub-headline h2 a{
+    color: #00b9ff;
+}
+
+.rewards .section.marquee-container .marquee-wrapper .marquee.block .marquee-content .text-cta-container .headline p picture img{
+    width: 30%;
+}
+
+.rewards .section.marquee-container .marquee-wrapper .marquee.block .marquee-content .text-cta-container .buttons-container p a{
+    margin-top: 10px;
+    margin-left: 0;
+}
+
+
+
+@media (width >= 768px) {
+    .banner-image.block {
+        &.min-height {
+            min-height: 380px;
+        }
+
+        &.small.min-height {
+            min-height: 294px;
+        }
+    }
+
+    .banner-content {
+
+        .text-cta-container {
+            > .buttons-container {
+                width: fit-content;
+            }
+            }
+        }
+
+        .sub-headline picture {
+            text-align: center;
+        }
+    }
+
+@media (width >= 1024px) {
+    .banner-image.block {
+        height: 100%;
+
+        &.small .buttons-container {
+            position: absolute;
+            right: 8%;
+            top: 38%;
+        }
+
+        &.min-height {
+            min-height: 470px;
+        }
+
+        &.small.min-height {
+            min-height: 206px;
+        }
+    }
+
+    .banner-content {
+        flex-direction: row;
+        padding: 80px 8%;
+        align-items: center;
+        justify-content: space-between;
+
+        .text-cta-container {
+            padding-right: 1.5rem;
+            margin: unset;
+
+            .buttons-container {
+                display: block;
+                margin: 0;
+            }
+        }
+
+        .foreground-container {
+            margin: 0;
+        }
+
+        .buttons-container .button-container {
+            text-align: center;
+        }
+    }
+
+    .small .banner-content {
+            padding: 60px 8%;
+    }
+}
+
+@media (width >= 1440px) {
+    .banner-content .text-cta-container {
+        margin:unset;
+    }
+}

--- a/aemedge/blocks/banner-image/banner-image.js
+++ b/aemedge/blocks/banner-image/banner-image.js
@@ -1,0 +1,120 @@
+import { createTag } from '../../scripts/utils.js';
+import { toClassName } from '../../scripts/aem.js';
+import { createOptimizedBackgroundImage } from '../../scripts/scripts.js';
+
+// read the config and construct the DOM
+function processBlockConfig(block) {
+  const bannerContent = createTag('div', { class: 'banner-content' });
+  const mediaDIV = createTag('div', { class: 'foreground-container' });
+  const nonMediaDIV = createTag('div', { class: 'text-cta-container' });
+  const btnsDIV = createTag('div', { class: 'buttons-container' });
+  let bgImages = [];
+  // data-analytics-props="{'event':'click','eventCategory':'cta','eventAction':'click','eventLabel':'${ctaText}'}"
+  block.querySelectorAll(':scope > div:not([id])').forEach((row) => {
+    if (row.children) {
+      const cols = [...row.children];
+      if (cols[1]) {
+        const col = cols[1];
+        const name = toClassName(cols[0].textContent);
+        cols[0].classList.add('config-property');
+        col.classList.add(name);
+        if (name === 'background') {
+          if (col.dataset.align) {
+            block.setAttribute('data-align', col.dataset.align);
+          }
+          if (col.dataset.valign) {
+            block.setAttribute('data-valign', col.dataset.valign);
+          }
+
+          const pictures = Array.from(col.querySelectorAll('img[src]'));
+          // if (extImageUrl.matches) {
+          //   bgImages = Array.from(pictures).map((source) => source.getAttribute('src'));
+          //   console.log('external images', bgImages);
+          // } else { // local image
+            bgImages = pictures.map((source) => new URL(source.getAttribute('src'), window.location.href).href);
+        //  }
+          // set image array as data attribute for storage
+          block.setAttribute('data-background', bgImages);
+
+        //   const extImageUrl = /dish\.scene7\.com|\/aemedge\/svgs\//;
+        //   const pictures = Array.from(col.querySelectorAll('picture > source:nth-child(2)'));
+        //   const additionalSources = Array.from(col.querySelectorAll('img[src]')); // Example of additional sources
+        //
+        //   const bgImages = pictures
+        //     .map((source) => new URL(source.getAttribute('srcset'), window.location.href).href)
+        //     .concat(
+        //       additionalSources
+        //         .filter((img) => extImageUrl.test(img.src))
+        //         .map((img) => new URL(img.src, window.location.href).href),
+        //     );
+         }
+
+        if (name === 'background-color') {
+          block.parentElement.style.backgroundColor = col.textContent
+        }
+        if (name === 'background-gradient') {
+          const colorHex = col.textContent;
+          const gradient = `linear-gradient(45deg, ${colorHex} 57%, transparent 95%`;
+          block.parentElement.style.background = gradient;
+        }
+        if (name === 'background-fit') {
+          block.style.backgroundSize = col.textContent;
+        }
+        if (name !== 'foreground') {
+          if (name.trim() === 'cta' || name.trim() === 'offer-details') {
+            btnsDIV.append(col);
+            nonMediaDIV.append(btnsDIV);
+          } else nonMediaDIV.append(col);
+        } else mediaDIV.append(col);
+
+        // Create data-analytics-props object for button only
+        const dataAnalyticsProps = {};
+        if (name === 'cta') {
+          const anchor = col.querySelector('a');
+          dataAnalyticsProps.event = 'click';
+          dataAnalyticsProps.eventCategory = 'cta';
+          dataAnalyticsProps.eventAction = 'click';
+          if (anchor) {
+            const ctaText = anchor.textContent;
+            dataAnalyticsProps.eventLabel = ctaText;
+          }
+          block.setAttribute('data-analytics-props', JSON.stringify(dataAnalyticsProps));
+        }
+        if (name !== 'cta' && name !== 'offer-details' && name !== 'headline' && name !== 'sub-headline'
+            && name !== 'foreground' && name !== 'background') {
+          col.remove();
+        }
+      }
+    }
+  });
+
+  if (mediaDIV.querySelector('.foreground')
+      && mediaDIV.querySelector('.foreground').children.length > 0) {
+    bannerContent.append(nonMediaDIV, mediaDIV);
+  } else {
+    bannerContent.append(nonMediaDIV);
+  }
+  block.append(bannerContent);
+  block.querySelectorAll('.config-property').forEach((prop) => prop.remove()); // remove config property divs from dom
+}
+
+export default function decorate(block) {
+  processBlockConfig(block);
+  const background = block.querySelector('.background');
+  const bgColor = block.querySelector('.background-color');
+  if (background) {
+    if (background.querySelector('picture')) {
+      createOptimizedBackgroundImage(block);
+      background.remove();
+    }
+  }
+  // set the bg color on the section
+  if (bgColor) {
+    const section = block.closest('.section');
+    if (section) {
+      section.style.backgroundColor = bgColor.textContent;
+    }
+    bgColor.remove();
+  }
+  block.querySelectorAll('div').forEach((div) => { if (div.children.length === 0) div.remove(); }); // remove empty divs
+}

--- a/aemedge/blocks/banner-image/banner-image.js
+++ b/aemedge/blocks/banner-image/banner-image.js
@@ -9,7 +9,7 @@ function processBlockConfig(block) {
   const nonMediaDIV = createTag('div', { class: 'text-cta-container' });
   const btnsDIV = createTag('div', { class: 'buttons-container' });
   let bgImages = [];
-  // data-analytics-props="{'event':'click','eventCategory':'cta','eventAction':'click','eventLabel':'${ctaText}'}"
+
   block.querySelectorAll(':scope > div:not([id])').forEach((row) => {
     if (row.children) {
       const cols = [...row.children];
@@ -27,30 +27,13 @@ function processBlockConfig(block) {
           }
 
           const pictures = Array.from(col.querySelectorAll('img[src]'));
-          // if (extImageUrl.matches) {
-          //   bgImages = Array.from(pictures).map((source) => source.getAttribute('src'));
-          //   console.log('external images', bgImages);
-          // } else { // local image
-            bgImages = pictures.map((source) => new URL(source.getAttribute('src'), window.location.href).href);
-        //  }
+          bgImages = pictures.map((source) => new URL(source.getAttribute('src'), window.location.href).href);
           // set image array as data attribute for storage
           block.setAttribute('data-background', bgImages);
-
-        //   const extImageUrl = /dish\.scene7\.com|\/aemedge\/svgs\//;
-        //   const pictures = Array.from(col.querySelectorAll('picture > source:nth-child(2)'));
-        //   const additionalSources = Array.from(col.querySelectorAll('img[src]')); // Example of additional sources
-        //
-        //   const bgImages = pictures
-        //     .map((source) => new URL(source.getAttribute('srcset'), window.location.href).href)
-        //     .concat(
-        //       additionalSources
-        //         .filter((img) => extImageUrl.test(img.src))
-        //         .map((img) => new URL(img.src, window.location.href).href),
-        //     );
-         }
+        }
 
         if (name === 'background-color') {
-          block.parentElement.style.backgroundColor = col.textContent
+          block.parentElement.style.backgroundColor = col.textContent;
         }
         if (name === 'background-gradient') {
           const colorHex = col.textContent;

--- a/aemedge/blocks/columns/columns.css
+++ b/aemedge/blocks/columns/columns.css
@@ -152,20 +152,6 @@
     }
   }
 
-  > div > div > p {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-    font-weight: 600;
-    margin: 0 0 1.25rem;
-  }
-
-  > div > div > h2 {
-    font-size: 2rem;
-    line-height: 2.75rem;
-    font-weight: 600;
-    margin: 1.25rem 0 ;
-  }
-
   .buttons-container {
     position: relative;
     margin: 0 auto;
@@ -189,21 +175,6 @@
     margin: 0 8%;
   }
 }
-
-
-  .banner.small .columns {
-    picture {
-      justify-content: left;
-    }
-
-    > div {
-      margin-top: 0;
-    }
-
-    &:first-child {
-      padding: 1.5rem;
-    }
-  }
 
   .section {
     padding: 0;

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -528,7 +528,6 @@ export function decorateExtImage() {
   // not for bitmap images because we're not doing renditions here
   const extImageUrl = /dish\.scene7\.com|\/aemedge\/svgs\//;
   const numberRegex = /\{(\d{1,2})?}/;
-  const numberTextRegex = /\{(\d.*)?\}/;
   const fragment = document.createDocumentFragment();
 
   document.querySelectorAll('a[href]').forEach((a) => {
@@ -543,26 +542,13 @@ export function decorateExtImage() {
       img.loading = 'lazy';
       img.src = extImageSrc;
       picture.append(img);
-      // Check if the link's text content matches numberRegex
-      const numberTextMatches = a.textContent.match(numberTextRegex);
+
       const numberMatches = a.textContent.match(numberRegex);
       if (numberMatches) {
-        console.log(numberMatches);
         const width = numberMatches[1];
-        if (numberTextMatches && numberTextMatches[0] === numberMatches[0]) {
-          img.style.maxWidth = `${width}`;
-        } else {
-          img.style.maxWidth = `${width}%`;
-        }
+        img.style.maxWidth = `${width}%`;
         a.textContent = a.textContent.replace(numberRegex, '');
       }
-
-      // const numberMatches = a.textContent.match(numberRegex);
-      // if (numberMatches) {
-      //   const width = numberMatches[1];
-      //   img.style.maxWidth = `${width}`;
-      //   a.textContent = a.textContent.replace(numberRegex, '');
-      // }
 
       fragment.append(picture);
       a.replaceWith(fragment);

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -391,7 +391,7 @@ export function decorateButtons(element) {
             a.className = 'button primary';
             twoup.classList.add('button-container');
           }
-          if (up.childNodes.length === 1 && up.tagName === 'EM' && threeup.childNodes.length === 1 && twoup.tagName === 'DEL' && (threeup.tagName === 'P' || twoup.tagName === 'DIV')) {
+          if (up.childNodes.length === 1 && up.tagName === 'EM' && threeup.childNodes.length === 1 && twoup.tagName === 'DEL' && (threeup.tagName === 'P' || threeup.tagName === 'DIV')) {
             a.className = 'button secondary';
             threeup.classList.add('button-container');
           }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -238,8 +238,12 @@ export function createOptimizedBackgroundImage(element, breakpoints = [
   const updateBackground = () => {
     const bgImage = getBackgroundImage(element);
     const extImageUrl = /dish\.scene7\.com|\/aemedge\/svgs\//;
+    // const pathname = extImageUrl.test(bgImage)
+    //   ? encodeURI(bgImage) : encodeURI(new URL(bgImage, window.location.href).pathname);
+
     const pathname = extImageUrl.test(bgImage)
-      ? encodeURI(bgImage) : encodeURI(new URL(bgImage, window.location.href).pathname);
+      ? bgImage
+      : new URL(bgImage, window.location.href).pathname;
 
     const matchedBreakpoint = breakpoints
       .filter((br) => !br.media || window.matchMedia(br.media).matches)
@@ -543,10 +547,12 @@ export function decorateExtImage() {
       img.src = extImageSrc;
       picture.append(img);
 
+      // Check if the link's text content matches numberRegex
       const numberMatches = a.textContent.match(numberRegex);
       if (numberMatches) {
-        const width = numberMatches[1];
-        img.style.maxWidth = `${width}%`;
+        const percentWidth = numberMatches[1];
+        img.style.maxWidth = `${percentWidth}%`;
+        // Remove the text content matching numberRegex
         a.textContent = a.textContent.replace(numberRegex, '');
       }
 

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -155,7 +155,6 @@ function autolinkModals(element) {
 
 export function buildMultipleButtons(main) {
   const buttons = main.querySelectorAll('.button-container:not(.subtext)');
-  const fragment = document.createDocumentFragment();
 
   buttons.forEach((button) => {
     const parent = button.parentElement;
@@ -178,36 +177,29 @@ export function buildMultipleButtons(main) {
   });
 
   const buttonGroups = main.querySelectorAll('div.button-container.combined');
-  // begin grouping buttons that have subtext
   buttonGroups.forEach((buttonGroup) => {
     const parent = buttonGroup.parentElement;
     const siblingButton = buttonGroup.nextElementSibling;
     const siblingUp = buttonGroup.previousElementSibling;
 
     if (!parent.classList.contains('buttons-container')) {
-      // case for grouping 2 subtext buttons
       if (siblingButton && siblingButton.classList.contains('combined')) {
         const buttonContainer = createTag('div', { class: 'buttons-container' });
         parent.insertBefore(buttonContainer, buttonGroup);
         buttonContainer.append(buttonGroup, siblingButton);
       }
-      // case for grouping 1 subtext button and 1 button P
       if (siblingButton && siblingButton.classList.contains('button-container') && !siblingButton.classList.contains('combined')) {
         const buttonContainer = createTag('div', { class: 'buttons-container' });
         parent.insertBefore(buttonContainer, buttonGroup);
         buttonContainer.append(buttonGroup, siblingButton);
       }
-      // case for grouping 1 button P and 1 subtext button
       if (siblingUp && siblingUp.classList.contains('button-container') && !siblingUp.classList.contains('combined')) {
         const buttonContainer = createTag('div', { class: 'buttons-container' });
         parent.insertBefore(buttonContainer, buttonGroup);
-        buttonContainer.append(siblingUp);
-        buttonContainer.append(buttonGroup);
+        buttonContainer.append(siblingUp, buttonGroup);
       }
     }
   });
-
-  main.appendChild(fragment);
 }
 
 /**
@@ -228,18 +220,15 @@ export function buildMultipleButtons(main) {
  * breakpoint should be used.
  */
 
-const resizeListeners = new WeakMap();
-function getBackgroundImage(section) {
-  // look for "background" values in the section metadata
-  const bgImages = section.dataset.background.split(',');
-  if (bgImages.length === 1) {
-    return bgImages[0].trim();
-  } // if there are 2 images, first is for desktop and second is for mobile
-  return (window.innerWidth > 1024 && bgImages.length === 2)
-    ? bgImages[0].trim() : bgImages[1].trim();
+export const resizeListeners = new WeakMap();
+export function getBackgroundImage(element) {
+  const sectionData = element.dataset.background;
+  const bgImages = sectionData.split(',').map((img) => img.trim());
+  return (bgImages.length === 1
+    || (window.innerWidth > 1024 && bgImages.length === 2)) ? bgImages[0] : bgImages[1];
 }
 
-function createOptimizedBackgroundImage(section, breakpoints = [
+export function createOptimizedBackgroundImage(element, breakpoints = [
   { width: '450' },
   { media: '(min-width: 450px)', width: '768' },
   { media: '(min-width: 768px)', width: '1024' },
@@ -247,31 +236,33 @@ function createOptimizedBackgroundImage(section, breakpoints = [
   { media: '(min-width: 1600px)', width: '2000' },
 ]) {
   const updateBackground = () => {
-    const bgImage = getBackgroundImage(section);
-    const url = new URL(bgImage, window.location.href);
-    const pathname = encodeURI(url.pathname);
+    const bgImage = getBackgroundImage(element);
+    const extImageUrl = /dish\.scene7\.com|\/aemedge\/svgs\//;
+    const pathname = extImageUrl.test(bgImage)
+      ? encodeURI(bgImage) : encodeURI(new URL(bgImage, window.location.href).pathname);
 
-    const matchedBreakpoints = breakpoints.filter(
-      (br) => !br.media || window.matchMedia(br.media).matches,
-    );
-    // If there are any matching breakpoints, pick the one with the highest resolution
-    const matchedBreakpoint = matchedBreakpoints.reduce(
-      (acc, curr) => (parseInt(curr.width, 10) > parseInt(acc.width, 10) ? curr : acc),
-      breakpoints[0],
-    );
+    const matchedBreakpoint = breakpoints
+      .filter((br) => !br.media || window.matchMedia(br.media).matches)
+      .reduce((acc, curr) => (parseInt(curr.width, 10)
+      > parseInt(acc.width, 10) ? curr : acc), breakpoints[0]);
 
     const adjustedWidth = matchedBreakpoint.width * window.devicePixelRatio;
-    section.style.backgroundImage = `url(${pathname}?width=${adjustedWidth}&format=webply&optimize=highest)`;
-    section.style.backgroundSize = 'cover';
+    element.style.backgroundImage = extImageUrl.test(bgImage) ? `url(${pathname}`
+      : `url(${pathname}?width=${adjustedWidth}&format=webply&optimize=highest)`;
   };
 
-  if (resizeListeners.has(section)) {
-    window.removeEventListener('resize', resizeListeners.get(section));
+  if (resizeListeners.has(element)) {
+    window.removeEventListener('resize', resizeListeners.get(element));
   }
-
-  resizeListeners.set(section, updateBackground);
+  resizeListeners.set(element, updateBackground);
   window.addEventListener('resize', updateBackground);
   updateBackground();
+}
+
+function decorateStyledSections(main) {
+  Array.from(main.querySelectorAll('.section[data-background]')).forEach((section) => {
+    createOptimizedBackgroundImage(section);
+  });
 }
 
 /**
@@ -309,18 +300,6 @@ function makeTwoColumns(main) {
   });
 }
 
-/**
- * Finds all sections in the main element of the document
- * that require adding a background image
- * @param {Element} main
- */
-
-function decorateStyledSections(main) {
-  Array.from(main.querySelectorAll('.section[data-background]')).forEach((section) => {
-    createOptimizedBackgroundImage(section);
-  });
-}
-
 async function buildGlobalBanner(main) {
   const banner = getMetadata('global-banner');
   if (banner) {
@@ -349,105 +328,72 @@ async function setNavType() {
 }
 
 /**
-   * Decorates paragraphs containing a single link as buttons.
-   * @param {Element} element container element
-   */
+ * Decorates paragraphs containing a single link as buttons.
+ * @param {Element} element container element
+ */
 export function decorateButtons(element) {
   element.querySelectorAll('a').forEach((a) => {
-    // Set the title attribute if not already set
     a.title = a.title || a.textContent;
-    // Proceed only if href is different from textContent, is not a fragment link,
-    // and is not an external image
     const extImageUrl = /dish\.scene7\.com|\/aemedge\/svgs\//;
     if (a.href !== a.textContent && !a.href.includes('/fragments/') && !extImageUrl.test(a.href)) {
       const hasIcon = a.querySelector('.icon');
+      if (hasIcon || a.querySelector('img')) return;
+
       const up = a.parentElement;
       const twoup = up.parentElement;
       const threeup = twoup.parentElement;
+      const childTag = a?.firstChild?.tagName?.toLowerCase();
+      const isSubscript = childTag === 'sub';
+      const isSuperscript = childTag === 'sup';
+      const isEm = up.tagName === 'EM';
 
-      // Skip processing if the <a> contains an icon
-      if (hasIcon) return;
+      if (isSubscript && !isEm) {
+        a.classList.add('blue');
+        up.classList.add('button-container', 'subtext');
+      } else if (isSubscript && isEm) {
+        a.classList.add('white');
+        twoup.classList.add('button-container', 'subtext');
+      } else if (isSuperscript) {
+        a.classList.add('black');
+        up.classList.add('button-container', 'subtext');
+      } else {
+        const linkText = a.textContent;
+        const linkTextEl = document.createElement('span');
+        linkTextEl.classList.add('link-button-text');
+        linkTextEl.textContent = linkText;
+        a.setAttribute('aria-label', linkText);
 
-      // Skip processing if the <a> contains an <img>
-      if (!a.querySelector('img')) {
-        // Detect if the <a> is inside <sub> or <sup>
-        const childTag = a?.firstChild?.tagName;
-        let Tagname = '';
-        if (childTag) {
-          Tagname = childTag.toLowerCase();
+        if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
+          a.textContent = '';
+          a.className = 'button text';
+          up.classList.add('button-container');
+          a.append(linkTextEl);
         }
-        const isSubscript = Tagname === 'sub';
-        const isSuperscript = Tagname === 'sup';
-        const isEm = up.tagName === 'EM';
-        if (isSubscript && !isEm) {
-          a.classList.add('blue');
-          up.classList.add('button-container', 'subtext');
-        } else if (isSubscript && isEm) {
-          a.classList.add('white');
-          twoup.classList.add('button-container', 'subtext');
-        } else if (isSuperscript) {
-          a.classList.add('black');
-          up.classList.add('button-container', 'subtext');
-        } else {
-          const linkText = a.textContent;
-          const linkTextEl = document.createElement('span');
-          linkTextEl.classList.add('link-button-text');
-          linkTextEl.textContent = linkText;
 
-          // Set aria-label for accessibility
-          a.setAttribute('aria-label', linkText);
-
-          // Modify the <a> content based on its parent element
-          if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
-            a.textContent = ''; // Clear existing text
-            a.className = 'button text'; // Assign default button classes
-            up.classList.add('button-container'); // Add container class to parent
-            a.append(linkTextEl); // Append the new span with link text
+        const pageType = getPageType();
+        if (pageType === 'blog') {
+          if (up.childNodes.length === 1 && up.tagName === 'DEL' && twoup.childNodes.length === 1 && (twoup.tagName === 'P' || twoup.tagName === 'DIV')) {
+            a.className = 'button primary';
+            if (a.href.includes('/cart/')) a.target = '_blank';
+            twoup.classList.add('button-container');
           }
-
-          // Handle specific button styles based on page type and parent tags
-          if (getPageType() === 'blog') {
-            // Primary buttons in blog pages
-            if (
-              up.childNodes.length === 1 && up.tagName === 'DEL' && twoup.childNodes.length === 1 && (twoup.tagName === 'P' || twoup.tagName === 'DIV')
-            ) {
-              a.className = 'button primary';
-              if (a.href.includes('/cart/')) a.target = '_blank';
-              twoup.classList.add('button-container');
-            }
-
-            // Secondary buttons in blog pages
-            if (
-              up.childNodes.length === 1 && up.tagName === 'EM' && threeup.childNodes.length === 1 && twoup.tagName === 'DEL' && (threeup.tagName === 'P' || threeup.tagName === 'DIV')
-            ) {
-              a.className = 'button secondary';
-              if (a.href.includes('/cart/')) a.target = '_blank';
-              threeup.classList.add('button-container');
-            }
-          } else {
-            // Primary buttons in non-blog pages
-            if (
-              up.childNodes.length === 1 && up.tagName === 'DEL' && twoup.childNodes.length === 1 && (twoup.tagName === 'P' || twoup.tagName === 'DIV')
-            ) {
-              a.className = 'button primary';
-              twoup.classList.add('button-container');
-            }
-
-            // Secondary buttons in non-blog pages
-            if (
-              up.childNodes.length === 1 && up.tagName === 'EM' && threeup.childNodes.length === 1 && twoup.tagName === 'DEL' && (threeup.tagName === 'P' || threeup.tagName === 'DIV')
-            ) {
-              a.className = 'button secondary';
-              threeup.classList.add('button-container');
-            }
-
-            // Dark buttons
-            if (
-              up.childNodes.length === 1 && up.tagName === 'EM' && twoup.tagName === 'STRONG' && threeup.tagName === 'DEL' && (threeup.parentElement.tagName === 'P' || threeup.parentElement.tagName === 'DIV')
-            ) {
-              a.className = 'button dark';
-              threeup.parentElement.classList.add('button-container');
-            }
+          if (up.childNodes.length === 1 && up.tagName === 'EM' && threeup.childNodes.length === 1 && twoup.tagName === 'DEL' && (threeup.tagName === 'P' || threeup.tagName === 'DIV')) {
+            a.className = 'button secondary';
+            if (a.href.includes('/cart/')) a.target = '_blank';
+            threeup.classList.add('button-container');
+          }
+        } else {
+          if (up.childNodes.length === 1 && up.tagName === 'DEL' && twoup.childNodes.length === 1 && (twoup.tagName === 'P' || twoup.tagName === 'DIV')) {
+            a.className = 'button primary';
+            twoup.classList.add('button-container');
+          }
+          if (up.childNodes.length === 1 && up.tagName === 'EM' && threeup.childNodes.length === 1 && twoup.tagName === 'DEL' && (threeup.tagName === 'P' || twoup.tagName === 'DIV')) {
+            a.className = 'button secondary';
+            threeup.classList.add('button-container');
+          }
+          if (up.childNodes.length === 1 && up.tagName === 'EM' && twoup.tagName === 'STRONG' && threeup.tagName === 'DEL' && (threeup.parentElement.tagName === 'P' || threeup.parentElement.tagName === 'DIV')) {
+            a.className = 'button dark';
+            threeup.parentElement.classList.add('button-container');
           }
         }
       }
@@ -582,6 +528,7 @@ export function decorateExtImage() {
   // not for bitmap images because we're not doing renditions here
   const extImageUrl = /dish\.scene7\.com|\/aemedge\/svgs\//;
   const numberRegex = /\{(\d{1,2})?}/;
+  const numberTextRegex = /\{(\d.*)?\}/;
   const fragment = document.createDocumentFragment();
 
   document.querySelectorAll('a[href]').forEach((a) => {
@@ -596,15 +543,26 @@ export function decorateExtImage() {
       img.loading = 'lazy';
       img.src = extImageSrc;
       picture.append(img);
-
       // Check if the link's text content matches numberRegex
+      const numberTextMatches = a.textContent.match(numberTextRegex);
       const numberMatches = a.textContent.match(numberRegex);
       if (numberMatches) {
-        const percentWidth = numberMatches[1];
-        img.style.maxWidth = `${percentWidth}%`;
-        // Remove the text content matching numberRegex
+        console.log(numberMatches);
+        const width = numberMatches[1];
+        if (numberTextMatches && numberTextMatches[0] === numberMatches[0]) {
+          img.style.maxWidth = `${width}`;
+        } else {
+          img.style.maxWidth = `${width}%`;
+        }
         a.textContent = a.textContent.replace(numberRegex, '');
       }
+
+      // const numberMatches = a.textContent.match(numberRegex);
+      // if (numberMatches) {
+      //   const width = numberMatches[1];
+      //   img.style.maxWidth = `${width}`;
+      //   a.textContent = a.textContent.replace(numberRegex, '');
+      // }
 
       fragment.append(picture);
       a.replaceWith(fragment);

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -245,6 +245,7 @@ picture {
 
 .center, [data-align="center"] {
   text-align: center;
+    background-position-x: center;
 
     .button-container.combined {
         margin-left: auto !important;
@@ -254,18 +255,22 @@ picture {
 
 [data-valign="bottom"] {
     align-content: end;
+    background-position-y: bottom;
 }
 
 [data-valign="middle"] {
     align-content: center;
+    background-position-y: center;
 }
 
 [data-valign="top"] {
     align-content: start;
+    background-position-y: top;
 }
 
 [data-align="right"] {
     text-align: right;
+    background-position-x: right;
 
     .button-container.combined {
         margin-left: auto !important;
@@ -274,6 +279,7 @@ picture {
 
 [data-align="left"] {
     text-align: left;
+    background-position-x: left;
 }
 
 main pre {
@@ -419,14 +425,15 @@ button:disabled:hover {
 }
 
 .button-container {
-    margin: 0 0 12px;
+    &:has(.button-container) {
+        margin: 0 0 12px;
+    }
 
     sub, sup, em sup, em sub {
         display: block;
         text-align: center;
         font-style: italic;
         margin-top: 6px;
-        font-size: 0.875rem;
     }
 
     a.button {
@@ -573,6 +580,7 @@ main > .section {
   margin: 0;
   padding: 0;
   background-position: center;
+  background-size: cover;
 
   .buttons-container {
     text-align: center;
@@ -738,7 +746,7 @@ margin-bottom:10px;
 }
 }
 
-.section.marquee-container {
+.section.marquee-container, .section.banner-image-container {
   margin:0;
   padding:0;
   width: 100%;

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -548,7 +548,6 @@ main img {
 
 .icon img, img.svg {
   height: 100%;
-  width: 100%;
 }
 
 /* sections */


### PR DESCRIPTION
A new banner-image block to replace the section style "banner".
NOTE that there is a problem with order of operations when the banner is a fragment, and when the background images are external dynamic media images to be taken care of in issue#512, https://github.com/aemsites/sling/issues/512 .

Fix #507 

Test URLs:
- Before: https://main--sling--aemsites.aem.page/library/blocks/banner-image
- After: https://507-banners--sling--aemsites.aem.page/library/blocks/banner-image


- Before: https://main--sling--aemsites.aem.live/aemedge/fragments/home/banner/deals-banner
- After: https://507-banners--sling--aemsites.aem.live/aemedge/fragments/home/banner/deals-banner

- Before: https://main--sling--aemsites.aem.live/aemedge/fragments/growth/cfb-24/cfb-banner/football-banner-non-locals
- After: https://507-banners--sling--aemsites.aem.live/aemedge/fragments/growth/cfb-24/cfb-banner/football-banner-non-locals

-Before: https://main--sling--aemsites.aem.live/aemedge/fragments/rewards/freestream-rewards-banner/freestream-rewards-banner
-After: https://507-banners--sling--aemsites.aem.live/aemedge/fragments/rewards/freestream-rewards-banner/freestream-rewards-banner

see all those banners together on the home page:
- Before: https://main--sling--aemsites.aem.live
- After: https://507-banners--sling--aemsites.aem.live
