### PR TITLE
adding data attributes + fixing tds

### DIFF
--- a/aemedge/blocks/popular-blogs/popular-blogs.css
+++ b/aemedge/blocks/popular-blogs/popular-blogs.css
@@ -23,12 +23,6 @@
     align-items: center;
 }
 
-.popular-blogs .heading-wrapper img {
-    max-height: 36px;
-    max-width: 36px;
-    vertical-align: middle;
-}
-
 .popular-blogs .headline {
     color: #1d1d1d;
     font-size: 20px;

--- a/aemedge/blocks/popular-blogs/popular-blogs.js
+++ b/aemedge/blocks/popular-blogs/popular-blogs.js
@@ -127,8 +127,7 @@ export default async function decorate(block) {
       const headlineWrapper = createTag('div', { class: 'heading-wrapper' });
       const headingTitle = createTag('h4', { class: 'headline' });
       headingTitle.innerText = 'Most Popular';
-      const headingImg = createTag('img', { class: 'heading-img', src: '/whatson/images/whats-on-sling.png' });
-      headlineWrapper.append(headingImg, headingTitle);
+      headlineWrapper.append(headingTitle);
       const cardsWrapper = createTag('div', { class: 'slides-wrapper' });
       const cardsDiv = createTag('ul', { class: 'blog-slides' });
       let rendered = 0;

--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -10,6 +10,12 @@
   font-size: var(--body-font-size-xs);
 }
 
+.table.playoffs, .table.schedule {
+   td:not([data-align="right"], [data-align="left"]) {
+     text-align: center;
+   }
+}
+
 @media (width >= 768px) {
   .table table {
     font-size: var(--body-font-size-s);
@@ -22,24 +28,29 @@
   }
 }
 
+.table table th,
+.table table td { /* stylelint-disable-line */
+  padding: 0 6px;
+}
+
 .table table thead tr {
   border-top: 2px solid;
   border-bottom: 2px solid;
 }
 
-.table table tbody tr {
+/* bordered variant */
+.table.bordered table th,
+.table.bordered table td { /* stylelint-disable-line */
+  border: 1px solid;
+}
+
+.table:not(.playoffs, .schedule) table tbody tr {
   border-bottom: 1px solid;
-}
-
-.table table th {
-  font-weight: 700;
-}
-
-.table table th,
-.table table td {
-  padding: 0;
-  width: 25%;
   text-align: center;
+}
+
+.table table th { /* stylelint-disable-line */
+  font-weight: 700;
 }
 
 /* no header variant */
@@ -49,24 +60,13 @@
 
 .schedule.table table thead tr {
   background-color: rgb(0 30 120);
+  border-color: rgb(0 30 120);
   color: rgb(255 208 60);
 }
 
 .playoffs.table table tbody tr td p a.button.text {
   padding: 0;
   display: inline;
-}
-
-.schedule.table table thead tr,
-.schedule.table table tbody tr,
-.schedule table tbody td,
-.schedule table thead tr th,
-.playoffs.table table thead tr,
-.playoffs.table table tbody tr,
-.playoffs table tbody td,
-.playoffs table thead tr th {
-  border: none;
-  text-align: center;
 }
 
 .playoffs.table table thead tr {
@@ -76,13 +76,7 @@
 
 /* striped variant */
 .table.striped tbody tr:nth-child(odd) {
-  background-color: var(--overlay-background-color);
-}
-
-/* bordered variant */
-.table.bordered table th,
-.table.bordered table td {
-  border: 1px solid;
+  background-color: var(--light-grey-color);
 }
 
 * {
@@ -103,8 +97,7 @@
 
 .playoffs.table table .single-column-row.lightgrey td, .schedule.table table .single-column-row.lightgrey td {
   background-color: var(--dark-color);
-  text-align: left;
-  padding-left: 6px;
+
 }
 
 .schedule.table p,

--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -8,40 +8,28 @@
   max-width: 100%;
   border-collapse: collapse;
   font-size: var(--body-font-size-xs);
-}
 
-.table.playoffs, .table.schedule {
-   td:not([data-align="right"], [data-align="left"]) {
-     text-align: center;
-   }
-}
+  th, td {
+    padding: 0 6px;
+  }
 
-@media (width >= 768px) {
-  .table table {
-    font-size: var(--body-font-size-s);
+  thead tr {
+    border-top: 2px solid;
+    border-bottom: 2px solid;
   }
 }
 
-@media (width >= 992px) {
-  .table table {
-    font-size: var(--body-font-size-m);
-  }
-}
-
-.table table th,
-.table table td { /* stylelint-disable-line */
-  padding: 0 6px;
-}
-
-.table table thead tr {
-  border-top: 2px solid;
-  border-bottom: 2px solid;
-}
 
 /* bordered variant */
 .table.bordered table th,
 .table.bordered table td { /* stylelint-disable-line */
   border: 1px solid;
+}
+
+.table.playoffs, .table.schedule {
+  td:not([data-align="right"], [data-align="left"]) {
+    text-align: center;
+  }
 }
 
 .table:not(.playoffs, .schedule) table tbody tr {
@@ -144,6 +132,10 @@ div.section.table-container .default-content-wrapper .button-container ~ p {
 }
 
 @media (width >= 768px) {
+  .table table {
+    font-size: var(--body-font-size-s);
+  }
+
   .blog-article > main div.section.table-container {
     padding: unset;
     width: unset;
@@ -154,6 +146,12 @@ div.section.table-container .default-content-wrapper .button-container ~ p {
   .playoffs.table, .schedule.table{
     margin-left: 8px;
     margin-bottom: 48px;
+  }
+}
+
+@media (width >= 992px) {
+  .table table {
+    font-size: var(--body-font-size-m);
   }
 }
 

--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -116,21 +116,6 @@ blockquote {
   table-layout: fixed;
 }
 
-div.section.table-container .default-content-wrapper .button-container {
-  text-align: left;
-  background-color: var(--background-color);
-}
-
-div.section.table-container .default-content-wrapper .button-container a {
-  text-align: left;
-  background-color: var(--background-color);
-  border: none;
-}
-
-div.section.table-container .default-content-wrapper .button-container ~ p {
-  text-align: left;
-}
-
 @media (width >= 768px) {
   .table table {
     font-size: var(--body-font-size-s);

--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -17,6 +17,10 @@
     border-top: 2px solid;
     border-bottom: 2px solid;
   }
+
+  td:not([data-align="right"], [data-align="justify"], [data-align="justify"]) {
+    text-align: center;
+  }
 }
 
 
@@ -26,19 +30,9 @@
   border: 1px solid;
 }
 
-.table.playoffs, .table.schedule {
-  td:not([data-align="right"], [data-align="left"]) {
-    text-align: center;
-  }
-}
 
 .table:not(.playoffs, .schedule) table tbody tr {
   border-bottom: 1px solid;
-  text-align: center;
-}
-
-.table table th { /* stylelint-disable-line */
-  font-weight: 700;
 }
 
 /* no header variant */
@@ -58,8 +52,10 @@
 }
 
 .playoffs.table table thead tr {
-  background-color: rgb(84 172 210);
-  color: white;
+  background-color: var(--dark-rock-candy);
+  border-color: var(--dark-rock-candy);
+  color: var(--clr-white);
+
 }
 
 /* striped variant */
@@ -112,7 +108,6 @@ blockquote {
 
 .playoffs.table table,
 .schedule.table table {
-  font-size: 16px;
   table-layout: fixed;
 }
 
@@ -131,12 +126,6 @@ blockquote {
   .playoffs.table, .schedule.table{
     margin-left: 8px;
     margin-bottom: 48px;
-  }
-}
-
-@media (width >= 992px) {
-  .table table {
-    font-size: var(--body-font-size-m);
   }
 }
 

--- a/aemedge/blocks/table/table.js
+++ b/aemedge/blocks/table/table.js
@@ -51,7 +51,6 @@ export default async function decorate(block) {
       tableRows.forEach((row) => {
         const cells = row.querySelectorAll('td');
         if (cells.length === 1) {
-          console.log('single column row', cells.length);
           trcount = 0;
           row.classList.add('single-column-row');
           const childCount = tableRows[1] ? tableRows[1].childElementCount : 1;

--- a/aemedge/blocks/table/table.js
+++ b/aemedge/blocks/table/table.js
@@ -18,49 +18,47 @@ export default async function decorate(block) {
   const tbody = document.createElement('tbody');
 
   const header = !block.classList.contains('no-header');
-  if (header) {
-    table.append(thead);
-    table.append(tbody);
+  table.append(thead);
+  table.append(tbody);
 
-    [...block.children].forEach((child, i) => {
-      const row = document.createElement('tr');
-      if (header && i === 0) thead.append(row);
-      else tbody.append(row);
-      [...child.children].forEach((col) => {
-        const cell = buildCell(header ? i : i + 1);
-        cell.innerHTML = col.innerHTML;
+  [...block.children].forEach((child, i) => {
+    const row = document.createElement('tr');
+    if (header && i === 0) thead.append(row);
+    else tbody.append(row);
+    [...child.children].forEach((col) => {
+      const cell = buildCell(header ? i : i + 1);
+      cell.innerHTML = col.innerHTML;
 
-        // Add data attributes if present
-        if (col.dataset.align) {
-          cell.setAttribute('data-align', col.dataset.align);
-        }
-        if (col.dataset.valign) {
-          cell.setAttribute('data-valign', col.dataset.valign);
-        }
+      // Add data attributes if present
+      if (col.dataset.align) {
+        cell.setAttribute('data-align', col.dataset.align);
+      }
+      if (col.dataset.valign) {
+        cell.setAttribute('data-valign', col.dataset.valign);
+      }
 
-        row.append(cell);
-      });
+      row.append(cell);
     });
-    block.innerHTML = '';
-    block.append(table);
+  });
+  block.innerHTML = '';
+  block.append(table);
 
-    const tableRows = block.querySelectorAll('table tbody tr');
-    let trcount = 0;
+  const tableRows = block.querySelectorAll('table tbody tr');
+  let trcount = 0;
 
-    if (tableRows) {
-      tableRows.forEach((row) => {
-        const cells = row.querySelectorAll('td');
-        if (cells.length === 1) {
-          trcount = 0;
-          row.classList.add('single-column-row');
-          const childCount = tableRows[1] ? tableRows[1].childElementCount : 1;
-          cells[0].setAttribute('colspan', childCount);
-        }
-        if (trcount % 2 === 0) {
-          row.classList.add('lightgrey');
-        }
-        trcount += 1;
-      });
-    }
+  if (tableRows) {
+    tableRows.forEach((row) => {
+      const cells = row.querySelectorAll('td');
+      if (cells.length === 1) {
+        trcount = 0;
+        row.classList.add('single-column-row');
+        const childCount = tableRows[1] ? tableRows[1].childElementCount : 1;
+        cells[0].setAttribute('colspan', childCount);
+      }
+      if (trcount % 2 === 0) {
+        row.classList.add('lightgrey');
+      }
+      trcount += 1;
+    });
   }
 }

--- a/aemedge/blocks/table/table.js
+++ b/aemedge/blocks/table/table.js
@@ -20,46 +20,48 @@ export default async function decorate(block) {
   const header = !block.classList.contains('no-header');
   if (header) {
     table.append(thead);
-  }
-  table.append(tbody);
+    table.append(tbody);
 
-  [...block.children].forEach((child, i) => {
-    const row = document.createElement('tr');
-    if (header && i === 0) thead.append(row);
-    else tbody.append(row);
-    [...child.children].forEach((col) => {
-      const cell = buildCell(header ? i : i + 1);
-      cell.innerHTML = col.innerHTML;
-      row.append(cell);
-    });
-  });
-  block.innerHTML = '';
-  block.append(table);
+    [...block.children].forEach((child, i) => {
+      const row = document.createElement('tr');
+      if (header && i === 0) thead.append(row);
+      else tbody.append(row);
+      [...child.children].forEach((col) => {
+        const cell = buildCell(header ? i : i + 1);
+        cell.innerHTML = col.innerHTML;
 
-  let tableRows = '';
-  if (block.classList.contains('schedule')) {
-    const scheduletableRows = block.querySelectorAll('table tbody tr');
-    tableRows = scheduletableRows;
-  } else if (block.classList.contains('playoffs')) {
-    const playoffstableRows = block.querySelectorAll('table tbody tr');
-    tableRows = playoffstableRows;
-  }
-  let trcount = 0;
-  if (tableRows) {
-    tableRows.forEach((row) => {
-      const cells = row.querySelectorAll('td');
-      if (cells.length === 1) {
-        trcount = 0;
-        row.classList.add('single-column-row');
-        for (let i = 0; i < tableRows[1].childElementCount - 1; i += 1) {
-          const newCell = document.createElement('td');
-          row.appendChild(newCell);
+        // Add data attributes if present
+        if (col.dataset.align) {
+          cell.setAttribute('data-align', col.dataset.align);
         }
-      }
-      if (trcount % 2 === 0) {
-        row.classList.add('lightgrey');
-      }
-      trcount += 1;
+        if (col.dataset.valign) {
+          cell.setAttribute('data-valign', col.dataset.valign);
+        }
+
+        row.append(cell);
+      });
     });
+    block.innerHTML = '';
+    block.append(table);
+
+    const tableRows = block.querySelectorAll('table tbody tr');
+    let trcount = 0;
+
+    if (tableRows) {
+      tableRows.forEach((row) => {
+        const cells = row.querySelectorAll('td');
+        if (cells.length === 1) {
+          console.log('single column row', cells.length);
+          trcount = 0;
+          row.classList.add('single-column-row');
+          const childCount = tableRows[1] ? tableRows[1].childElementCount : 1;
+          cells[0].setAttribute('colspan', childCount);
+        }
+        if (trcount % 2 === 0) {
+          row.classList.add('lightgrey');
+        }
+        trcount += 1;
+      });
+    }
   }
 }

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -277,7 +277,7 @@ picture {
     }
 }
 
-[data-align="left"] {
+[data-align="left"], [data-align="justify"] {
     text-align: left;
     background-position-x: left;
 }


### PR DESCRIPTION
- now there is only a single TD when the block table only has a single cell in a row
- align and valign attributes have been added to TDs so authors can change alignment natively

Fix #516 

Test URLs:
- Before: https://main--sling--aemsites.aem.page/library/blocks/table
- After: https://516-tdwidth--sling--aemsites.aem.page/library/blocks/table

- Before: https://main--sling--aemsites.aem.page/whatson/sports/general-sports/stream-nascar-racing-live
- After: https://516-tdwidth--sling--aemsites.aem.page/whatson/sports/general-sports/stream-nascar-racing-live
