### PR TITLE
Add white background variant for columns block

### DIFF
--- a/aemedge/blocks/columns/columns.css
+++ b/aemedge/blocks/columns/columns.css
@@ -48,6 +48,7 @@
   }
 }
 
+
 .columns.cards > div > div {
   border-radius: 4px;
   box-shadow: 0 5px 15px 0 rgb(0 0 0 / 14%);
@@ -327,6 +328,13 @@
 
     .tabs-panel .columns > div {
       flex-direction: column;
+    }
+    
+    .columns.white > div {
+      background-color: white;
+      margin-top: 30px;
+      padding: 30px;
+    
     }
 
     .columns.landing {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #541 
This will be used along with device variant introduced in https://github.com/aemsites/sling/pull/540 

Test URLs:
- Before: https://main--sling--aemsites.aem.live/drafts/import-02-24/supported-devices/airtv-mini
- After: https://whitebg--sling--aemsites.aem.page/drafts/import-02-24/supported-devices/airtv-mini
