### PR TITLE
Add videoblock to script.js

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -25,6 +25,7 @@ import {
   loadPackageCards,
   linkTextIncludesHref,
   centerHeadlines,
+  buildVideoBlocks,
 } from './utils.js';
 
 const LCP_BLOCKS = ['category']; // add your LCP blocks to the list
@@ -616,6 +617,7 @@ export function decorateMain(main) {
   extractElementsColor();
   decorateExtImage(main);
   decorateLinkedImages();
+  buildVideoBlocks(main);
 }
 
 /**

--- a/aemedge/templates/blog-article/blog-article.js
+++ b/aemedge/templates/blog-article/blog-article.js
@@ -1,6 +1,5 @@
 import {
   createTag,
-  buildVideoBlocks,
   buildFragmentBlocks,
   buildAuthorLink,
 } from '../../scripts/utils.js';
@@ -165,6 +164,5 @@ export default async function buildBlogDetails(main) {
   const p = contentWrapper.querySelector('.default-content-wrapper:first-of-type > p:first-of-type');
   if (p) p.remove();
   buildFragmentBlocks(main);
-  buildVideoBlocks(main);
   decorateAwardIcons(main);
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #542 

Test URLs:
- Before: https://main--sling--aemsites.aem.page/drafts/import-02-24/programming/sports/college-football
- After: https://videob--sling--aemsites.aem.live/drafts/import-02-24/programming/sports/college-football 

Existing blog pages for which the videoblock was added in blog-article.js and is removed in this PR. 
https://main--sling--aemsites.aem.live/whatson/sports/college-basketball/watch-womens-final-four-live


