### PR TITLE
fix white links in columns

### DIFF
--- a/aemedge/blocks/columns/columns.css
+++ b/aemedge/blocks/columns/columns.css
@@ -114,7 +114,7 @@
        margin-right: 12px;
      }
 
-    h1, h2, h3, h4, h5, h6, p, li {
+    h1, h2, h3, h4, h5, h6, p, li, a {
       color: var(--clr-white);
     }
     }
@@ -130,7 +130,6 @@
   }
 
     a:not(.button, .blue, .black, .white) {
-      color: var(--clr-white);
       text-decoration: underline;
     }
   }


### PR DESCRIPTION

Fix #547 

Test URLs:
See that the first columns link is now blue, but the dark blue skinny column lower on the page with a link is still white.
- Before: https://main--sling--aemsites.aem.page/library/blocks/columns
- After: https://547-whitelinks--sling--aemsites.aem.page/library/blocks/columns

- Before: https://main--sling--aemsites.aem.live/supported-devices/samsung
- After: https://547-whitelinks--sling--aemsites.aem.live/supported-devices/samsung